### PR TITLE
Implement partial SVG generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,4 @@ name = "osmflatc"
 path = "src/main.rs"
 
 [[example]]
-name = "render"
+name = "render-svg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,7 @@ prost-build = "0.3"
 
 [dev-dependencies]
 proptest = "0.6.0"
-png = "0.12"
-bresenham = "0.1"
 svg = "0.5"
-haversine = "0.2"
 
 [[bin]]
 name = "osmflatc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "1.2"
 bytes = "0.4"
 colored = "1.6"
 failure = "0.1"
-flatdata = { git = "https://github.com/boxdot/flatdata-rs", rev = "df86fda4" }
+flatdata = { path = "../flatdata-rs" }
 flate2 = "1.0"
 itertools = "0.7"
 log = "0.4"
@@ -31,6 +31,7 @@ prost-build = "0.3"
 [dev-dependencies]
 proptest = "0.6.0"
 svg = "0.5"
+smallvec = "0.6"
 
 [[bin]]
 name = "osmflatc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ prost-build = "0.3"
 proptest = "0.6.0"
 png = "0.12"
 bresenham = "0.1"
+svg = "0.5"
+haversine = "0.2"
 
 [[bin]]
 name = "osmflatc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "1.2"
 bytes = "0.4"
 colored = "1.6"
 failure = "0.1"
-flatdata = { path = "../flatdata-rs" }
+flatdata = { git = "https://github.com/boxdot/flatdata-rs", rev = "df86fda4" }
 flate2 = "1.0"
 itertools = "0.7"
 log = "0.4"

--- a/examples/render-svg.rs
+++ b/examples/render-svg.rs
@@ -405,7 +405,7 @@ struct Args {
     osmflat_archive: PathBuf,
 
     /// SVG filename to output
-    #[structopt(parse(from_os_str))]
+    #[structopt(short = "o", long = "output", parse(from_os_str))]
     output: PathBuf,
 
     /// Width of the image

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -297,6 +297,7 @@ where
     let mut document = Document::new().set("viewBox", (0, 0, width, height));
     let mut road_group = element::Group::new()
         .set("stroke", "#001F3F")
+        .set("stroke-width", "0.3")
         .set("fill", "none");
     let mut park_group = element::Group::new()
         .set("stroke", "#3D9970")

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -1,45 +1,39 @@
-extern crate bresenham;
-extern crate structopt;
-#[macro_use]
-extern crate failure;
 extern crate flatdata;
-extern crate haversine;
 extern crate itertools;
 extern crate osmflat;
-extern crate png;
+extern crate structopt;
 extern crate svg;
 
-use failure::Error;
 use flatdata::{Archive, FileResourceStorage};
-use png::HasParameters;
 use structopt::StructOpt;
-use svg::node::element::{Group, Polyline};
+use svg::node::element;
 use svg::Document;
 
-use std::convert;
-use std::fs::File;
-use std::io::BufWriter;
+use std::f64;
+use std::io;
+use std::ops::Range;
 use std::path::PathBuf;
-
 use std::str;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "osmflat-render")]
-struct Args {
-    #[structopt(short = "f", long = "flatdata-archive", parse(from_os_str))]
-    flatdata_archive: PathBuf,
-
-    #[structopt(short = "o", long = "output", parse(from_os_str))]
-    output: PathBuf,
-
-    #[structopt(short = "w", long = "width", default_value = "4000")]
-    flag_width: u32,
+/// Helper function to read a string from osmflat.
+fn substring(strings: &str, start: u64) -> &str {
+    let start = start as usize;
+    let end = strings[start..].find('\0').expect("invalid string");
+    &strings[start..start + end]
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
 struct GeoCoord {
     lat: f64,
     lon: f64,
+}
+
+impl Into<String> for GeoCoord {
+    fn into(self) -> String {
+        // Not, we need to revert lat/lon, since lat cooresponds to y-axis and lon to
+        // x-axis.
+        format!("{:.5},{:.5}", self.lon, self.lat)
+    }
 }
 
 impl GeoCoord {
@@ -58,7 +52,7 @@ impl GeoCoord {
     }
 }
 
-impl<'a> convert::From<osmflat::RefNode<'a>> for GeoCoord {
+impl<'a> From<osmflat::RefNode<'a>> for GeoCoord {
     fn from(node: osmflat::RefNode<'a>) -> Self {
         const COORD_SCALE: f64 = 0.000000001;
         Self {
@@ -68,147 +62,144 @@ impl<'a> convert::From<osmflat::RefNode<'a>> for GeoCoord {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-struct Color {
-    r: u8,
-    g: u8,
-    b: u8,
-    a: u8,
+struct Polyline {
+    inner: Vec<Range<u64>>, // TODO: use small vec optimization
 }
 
-#[derive(Debug)]
-struct Image {
-    w: u32,
-    h: u32,
-    data: Vec<u8>,
+impl From<Range<u64>> for Polyline {
+    fn from(range: Range<u64>) -> Self {
+        Self { inner: vec![range] }
+    }
 }
 
-impl Image {
-    fn new(w: u32, h: u32) -> Self {
-        Self {
-            w,
-            h,
-            data: vec![255; (w * h) as usize * 4],
+impl Polyline {
+    fn into_iter(self, archive: osmflat::Osm) -> PolylineIter {
+        let next_element = self.inner.first().map(|range| range.start).unwrap_or(0);
+        PolylineIter {
+            archive,
+            inner: self.inner,
+            next_range: 0,
+            next_element,
         }
     }
 }
 
-#[derive(Debug, Clone)]
-struct MapTransform {
-    width: u32,
-    height: u32,
-    min_x: f64,
-    min_y: f64,
-    map_w: f64,
-    map_h: f64,
+/// Iterator over osmflat nodes.
+///
+/// Polyline contains ranges of nodes. This iterator iterates over the ranges
+/// and resolves nodes as GeoCoord's.
+struct PolylineIter {
+    archive: osmflat::Osm,
+    inner: Vec<Range<u64>>,
+    next_range: usize,
+    next_element: u64,
 }
 
-impl MapTransform {
-    fn new(width: u32, height: u32, min: GeoCoord, max: GeoCoord) -> Self {
-        Self {
-            width,
-            height,
-            min_x: min.lon,
-            min_y: min.lat,
-            map_w: max.lon - min.lon,
-            map_h: max.lat - min.lat,
-        }
-    }
-
-    fn transform(&self, coord: GeoCoord) -> (isize, isize) {
-        (
-            ((coord.lon - self.min_x) / self.map_w * self.width as f64) as isize,
-            ((1f64 - (coord.lat - self.min_y) / self.map_h) * self.height as f64) as isize,
-        )
-    }
-
-    fn transform_meters(&self, distance: u32) -> u32 {
-        let start = haversine::Location {
-            latitude: self.min_x,
-            longitude: self.min_y,
-        };
-        let end = haversine::Location {
-            latitude: self.map_h / self.height as f64 + self.min_y,
-            longitude: self.map_w / self.width as f64 + self.min_x,
-        };
-        let pt_distance = haversine::distance(start, end, haversine::Units::Kilometers) / 1000.;
-        (distance as f64 / pt_distance) as u32
-    }
-}
-
-#[derive(Clone)]
-struct NodesIterator<'a> {
-    nodes: flatdata::ArrayView<'a, osmflat::Node>,
-    nodes_index: flatdata::ArrayView<'a, osmflat::NodeIndex>,
-    next: usize,
-    end: usize,
-}
-
-impl<'a> NodesIterator<'a> {
-    fn from_way_type(archive: &'a osmflat::Osm, way_type: &WayType) -> Self {
-        let (next, end) = match way_type {
-            WayType::Road {
-                start_node_idx,
-                end_node_idx,
-            } => (start_node_idx, end_node_idx),
-            WayType::River {
-                start_node_idx,
-                end_node_idx,
-                ..
-            } => (start_node_idx, end_node_idx),
-            _ => {
-                panic!("Can't interate on this WayType");
+impl Iterator for PolylineIter {
+    type Item = GeoCoord;
+    fn next(&mut self) -> Option<GeoCoord> {
+        if self.next_range < self.inner.len() {
+            let range = &self.inner[self.next_range];
+            if self.next_element < range.end {
+                let node_idx = self
+                    .archive
+                    .nodes_index()
+                    .at(self.next_element as usize)
+                    .value();
+                let coord = self.archive.nodes().at(node_idx as usize).into();
+                self.next_element += 1;
+                if self.next_element == range.end {
+                    self.next_range += 1;
+                    self.next_element = self
+                        .inner
+                        .get(self.next_range)
+                        .map(|range| range.start)
+                        .unwrap_or(0);
+                }
+                Some(coord)
+            } else {
+                None
             }
-        };
-        Self {
-            nodes: archive.nodes(),
-            nodes_index: archive.nodes_index(),
-            next: *next as usize,
-            end: *end as usize,
-        }
-    }
-}
-
-impl<'a> Iterator for NodesIterator<'a> {
-    type Item = osmflat::RefNode<'a>;
-    fn next<'b>(&'b mut self) -> Option<Self::Item> {
-        if self.next < self.end {
-            let idx = self.next;
-            self.next += 1;
-            Some(self.nodes.at(self.nodes_index.at(idx).value() as usize))
         } else {
             None
         }
     }
 }
 
-fn substring(strings: &str, start: u64) -> &str {
-    let start = start as usize;
-    let end = strings[start..].find('\0').expect("invalid string");
-    &strings[start..start + end]
-}
-
-enum WayType {
+#[derive(Debug, Clone, Copy)]
+enum Category {
+    Road,
     Park,
-    Lake,
-    Road {
-        start_node_idx: u64,
-        end_node_idx: u64,
-    },
-    River {
-        start_node_idx: u64,
-        end_node_idx: u64,
-        width: u32,
-    },
+    River(u32), // River with width
+    Water,
 }
 
-fn way_filter(
-    way: &osmflat::RefWay,
-    next_way: &osmflat::RefWay,
-    tags_index: &flatdata::ArrayView<osmflat::TagIndex>,
-    tags: &flatdata::ArrayView<osmflat::Tag>,
-    strings: &str,
-) -> Option<WayType> {
+struct Feature {
+    idx: u64,
+    cat: Category,
+}
+
+impl Feature {
+    fn into_polyline(self, archive: osmflat::Osm) -> Polyline {
+        match self.cat {
+            Category::Road | Category::River(_) => way_into_polyline(archive, self.idx),
+            Category::Park | Category::Water => multipolygon_into_polyline(archive, self.idx),
+        }
+    }
+}
+
+fn way_into_polyline(archive: osmflat::Osm, idx: u64) -> Polyline {
+    let way = archive.ways().at(idx as usize);
+    let next_way = archive.ways().at(idx as usize + 1);
+    let first_node_idx = way.ref_first_idx();
+    let last_node_idx = next_way.ref_first_idx();
+    Polyline {
+        inner: vec![first_node_idx..last_node_idx],
+    }
+}
+
+fn multipolygon_into_polyline(archive: osmflat::Osm, idx: u64) -> Polyline {
+    let members = archive.relation_members().at(idx as usize);
+    let strings = unsafe { str::from_utf8_unchecked(archive.stringtable()) };
+    let ways = archive.ways();
+
+    let inner = members
+        .filter_map(|m| match m {
+            osmflat::RefRelationMembers::WayMember(way_member) => {
+                let role = substring(strings, way_member.role_idx());
+                if role == "outer" {
+                    let way_idx = way_member.way_idx();
+                    let way = ways.at(way_idx as usize);
+                    let next_way = ways.at(way_idx as usize + 1);
+                    Some(way.ref_first_idx()..next_way.ref_first_idx())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .collect();
+    Polyline { inner }
+}
+
+fn classify(archive: osmflat::Osm) -> impl Iterator<Item = Feature> {
+    let inner_archive = archive.clone();
+    let ways = (0..archive.ways().len() as u64 - 2).filter_map(move |idx| {
+        classify_way(inner_archive.clone(), idx).map(|cat| Feature { idx, cat })
+    });
+    let rels = (0..archive.relations().len() as u64 - 2).filter_map(move |idx| {
+        classify_relation(archive.clone(), idx).map(|cat| Feature { idx, cat })
+    });
+    ways.chain(rels)
+}
+
+fn classify_way(archive: osmflat::Osm, idx: u64) -> Option<Category> {
+    let way = archive.ways().at(idx as usize);
+    let next_way = archive.ways().at(idx as usize + 1);
+    let tags = archive.tags();
+    let tags_index = archive.tags_index();
+    let strings = unsafe { str::from_utf8_unchecked(archive.stringtable()) };
+
     // Filter all ways that have less than 2 nodes.
     let start_node_idx = way.ref_first_idx();
     let end_node_idx = next_way.ref_first_idx();
@@ -237,232 +228,187 @@ fn way_filter(
             {
                 return None;
             }
-            return Some(WayType::Road {
-                start_node_idx,
-                end_node_idx,
-            });
+            return Some(Category::Road);
         } else if key == "waterway" {
-            for tag_idx in start_tag_idx..end_tag_idx {
-                //let tag = tags.at(tags_index.at(tag_idx as usize).value() as usize);
-                let key = substring(strings, tag.key_idx());
-                if key == "width" || key == "maxwidth" {
-                    let val = substring(strings, tag.value_idx());
-                    let width: u32 = val.parse().ok()?;
-                    return Some(WayType::River {
-                        start_node_idx,
-                        end_node_idx,
-                        width,
-                    });
-                }
+            let key = substring(strings, tag.key_idx());
+            if key == "width" || key == "maxwidth" {
+                let val = substring(strings, tag.value_idx());
+                let width: u32 = val.parse().ok()?;
+                return Some(Category::River(width));
             }
-            return Some(WayType::River {
-                start_node_idx,
-                end_node_idx,
-                width: 1,
-            });
+            return Some(Category::River(1));
         }
     }
-
     None
 }
 
-fn render(archive: &osmflat::Osm, output_path: &std::path::Path, width: u32) -> Result<(), Error> {
-    let relations = archive.relations();
-    let relation_members = archive.relation_members();
-    let ways = archive.ways();
-    let tags_index = archive.tags_index();
+fn classify_relation(archive: osmflat::Osm, idx: u64) -> Option<Category> {
+    let relation = archive.relations().at(idx as usize);
+    let next_relation = archive.relations().at(idx as usize + 1);
+
+    let start_tag_idx = relation.tag_first_idx();
+    let end_tag_idx = next_relation.tag_first_idx();
+
+    let mut is_multipolygon = false;
+    let mut is_park = false;
+    let mut is_lake = false;
+
     let tags = archive.tags();
-    let strings = str::from_utf8(archive.stringtable())
-        .expect("stringtable contains invalid utf8 characters");
+    let tags_index = archive.tags_index();
+    let strings = unsafe { str::from_utf8_unchecked(archive.stringtable()) };
 
-    println!("Relations: {}", relations.len());
-    let parks = relations
-        .iter()
-        .zip(relations.iter().skip(1))
-        .enumerate()
-        .filter_map(|(relation_idx, (relation, next_relation))| {
-            let start_tag_idx = relation.tag_first_idx();
-            let end_tag_idx = next_relation.tag_first_idx();
-            let mut is_multipolygon = false;
-            let mut is_park = false;
-            let mut is_lake = false;
-            for tag_idx in start_tag_idx..end_tag_idx {
-                let tag = tags.at(tags_index.at(tag_idx as usize).value() as usize);
-                let key = substring(strings, tag.key_idx());
-                let val = substring(strings, tag.value_idx());
-                if key == "type" && val == "multipolygon" {
-                    is_multipolygon = true;
-                }
-                if (key == "leisure" && val == "park")
-                    || (key == "landuse" && (val == "recreation_ground" || val == "forest"))
-                {
-                    is_park = true;
-                }
-                if key == "water" && val == "lake" {
-                    is_lake = true;
-                }
+    for tag_idx in start_tag_idx..end_tag_idx {
+        let tag = tags.at(tags_index.at(tag_idx as usize).value() as usize);
+        let key = substring(strings, tag.key_idx());
+        let val = substring(strings, tag.value_idx());
+        if key == "type" && val == "multipolygon" {
+            is_multipolygon = true;
+        }
+        if (key == "leisure" && val == "park")
+            || (key == "landuse" && (val == "recreation_ground" || val == "forest"))
+        {
+            is_park = true;
+        }
+        if key == "water" && val == "lake" {
+            is_lake = true;
+        }
+
+        if is_multipolygon {
+            if is_park {
+                return Some(Category::Park);
+            } else if is_lake {
+                return Some(Category::Water);
             }
-            if is_multipolygon {
-                if is_park {
-                    return Some((WayType::Park, relation_idx));
-                }
-            }
-            if is_lake {
-                return Some((WayType::Lake, relation_idx));
-            }
-            None
-        })
-        .map(|(way_type, relation_idx)| {
-            let members = relation_members.at(relation_idx);
-            let outline = members
-                .filter_map(|m| match m {
-                    osmflat::RefRelationMembers::WayMember(way_member) => {
-                        let role = substring(strings, way_member.role_idx());
-                        if role == "outer" {
-                            Some(way_member.way_idx())
-                        } else {
-                            None
-                        }
-                    }
-                    _ => None,
-                })
-                .map(|way_idx| {
-                    let way = archive.ways().at(way_idx as usize);
-                    let next_way = archive.ways().at(way_idx as usize + 1);
-                    (way.ref_first_idx(), next_way.ref_first_idx())
-                });
-
-            (way_type, outline)
-        });
-
-    let roads = ways
-        .iter()
-        .zip(ways.iter().skip(1))
-        .filter_map(|(way, next_way)| way_filter(&way, &next_way, &tags_index, &tags, strings));
-
-    // compute extent
-    let mut coords = roads
-        .clone()
-        .flat_map(|way_type| NodesIterator::from_way_type(archive, &way_type).map(GeoCoord::from));
-
-    let first_coord = coords.next().expect("no roads found");
-    let (min, max) = coords.fold((first_coord, first_coord), |(min, max), coord| {
-        (min.min(coord), max.max(coord))
-    });
-
-    // compute ratio and height
-    let ratio = 360. / 180. * (max.lat - min.lat) / (max.lon - min.lon);
-    let height = (width as f64 * ratio) as u32;
-
-    // create world -> raster transformation
-    let t = MapTransform::new(width - 1, height - 1, min, max);
-
-    // create paths
-    let paths = roads.map(|way_type| {
-        let raster_coords = NodesIterator::from_way_type(archive, &way_type)
-            .map(GeoCoord::from)
-            .map(|coord| t.transform(coord));
-        (raster_coords.collect(), way_type)
-    });
-
-    let park_paths = parks.map(|(way_type, park)| {
-        let coordinates = park.fold(vec![], |mut acc, (start_node_idx, end_node_idx)| {
-            let nodes = NodesIterator {
-                nodes: archive.nodes(),
-                nodes_index: archive.nodes_index(),
-                next: start_node_idx as usize,
-                end: end_node_idx as usize,
-            };
-            for node in nodes {
-                acc.push(t.transform(GeoCoord::from(node)))
-            }
-            acc
-        });
-
-        (coordinates, way_type)
-    });
-
-    // detect whether we export svg or render to png
-    match output_path.extension() {
-        Some(os_str) => match os_str.to_str() {
-            Some("png") => {
-                let file = File::create(output_path)?;
-                let buf = BufWriter::new(file);
-                let mut image = Image::new(width, height);
-                let mut encoder = png::Encoder::new(buf, width, image.h);
-                encoder.set(png::ColorType::RGBA).set(png::BitDepth::Eight);
-                let mut writer = encoder.write_header()?;
-                // for (nodes_iterator, width) in paths {
-                //     //for (x, y) in Bresenham::new(from, to) {
-                //     //    image.set(x as u32, y as u32, Color::new(0, 0, 0, 255));
-                //     //}
-                // }
-                writer.write_image_data(&image.data[..])?;
-            }
-            Some("svg") => {
-                let mut document = Document::new().set("viewBox", (0, 0, width, height));
-                let mut road_group = Group::new().set("stroke", "#001F3F").set("fill", "none");
-                let mut park_group = Group::new()
-                    .set("stroke", "#3D9970")
-                    .set("fill", "#3D9970")
-                    .set("fill-opacity", 0.3);
-                let mut river_group = Group::new().set("stroke", "#0074D9").set("fill", "none");
-                let mut lake_group = Group::new()
-                    .set("stroke", "#0074D9")
-                    .set("fill", "#0074D9")
-                    .set("fill-opacity", 0.3);
-                for (mut nodes_iterator, way_type) in paths.chain(park_paths) {
-                    let v: Vec<String> = nodes_iterator
-                        .into_iter()
-                        .map(|(x, y)| format!("{},{}", x, y))
-                        .collect();
-                    match way_type {
-                        WayType::Road { .. } => {
-                            let mut polyline = Polyline::new().set("points", v.join(" "));
-                            road_group = road_group.add(polyline);
-                        }
-                        WayType::River {
-                            start_node_idx: _,
-                            end_node_idx: _,
-                            width,
-                        } => {
-                            let mut polyline = Polyline::new()
-                                .set("points", v.join(" "))
-                                .set("stroke-opacity", 0.8)
-                                .set("stroke-width", t.transform_meters(width * 20));
-                            river_group = river_group.add(polyline);
-                        }
-                        WayType::Park => {
-                            let mut polyline = Polyline::new().set("points", v.join(" "));
-                            park_group = park_group.add(polyline);
-                        }
-                        WayType::Lake => {
-                            println!("Rendering Lake");
-                            let mut polyline = Polyline::new().set("points", v.join(" "));
-                            lake_group = lake_group.add(polyline);
-                        }
-                    }
-                }
-
-                document = document
-                    .add(road_group)
-                    .add(park_group)
-                    .add(river_group)
-                    .add(lake_group);
-                svg::save(output_path, &document)?;
-            }
-            _ => bail!("File extension not supported."),
-        },
-        _ => bail!("Unable to guess format from file name (no extension)."),
+        }
     }
-    Ok(())
+    None
 }
 
-fn main() -> Result<(), Error> {
+fn render_svg<P>(
+    archive: osmflat::Osm,
+    classified_polylines: P,
+    output: PathBuf,
+    width: u32,
+    height: u32,
+) -> Result<(), io::Error>
+where
+    P: Iterator<Item = (Polyline, Category)>,
+{
+    let mut document = Document::new().set("viewBox", (0, 0, width, height));
+    let mut road_group = element::Group::new()
+        .set("stroke", "#001F3F")
+        .set("fill", "none");
+    let mut park_group = element::Group::new()
+        .set("stroke", "#3D9970")
+        .set("fill", "#3D9970")
+        .set("fill-opacity", 0.3);
+    let mut river_group = element::Group::new()
+        .set("stroke", "#0074D9")
+        .set("fill", "none")
+        .set("stroke-opacity", 0.8);
+    let mut lake_group = element::Group::new()
+        .set("stroke", "#0074D9")
+        .set("fill", "#0074D9")
+        .set("fill-opacity", 0.3);
+
+    let mut min_coord = GeoCoord {
+        lat: f64::MAX,
+        lon: f64::MAX,
+    };
+    let mut max_coord = GeoCoord {
+        lat: f64::MIN,
+        lon: f64::MIN,
+    };
+
+    for (poly, cat) in classified_polylines {
+        // TODO: Use itertools to avoid creation of intermediate vector and strings.
+        let poly: Vec<String> = poly
+            .into_iter(archive.clone())
+            .map(|coord| {
+                // collect extent
+                min_coord = min_coord.min(coord);
+                max_coord = max_coord.max(coord);
+                coord.into()
+            })
+            .collect();
+        let mut polyline = element::Polyline::new()
+            .set("points", poly.join(" "))
+            .set("vector-effect", "non-scaling-stroke");
+
+        match cat {
+            Category::Road => {
+                road_group = road_group.add(polyline);
+            }
+            Category::River(width) => {
+                river_group = river_group.add(polyline).set("stroke-width", width);
+            }
+            Category::Park => {
+                park_group = park_group.add(polyline);
+            }
+            Category::Water => {
+                lake_group = lake_group.add(polyline);
+            }
+        }
+    }
+
+    let mut transform = element::Group::new().set(
+        "transform",
+        format!(
+            "scale({:.5} {:.5}) translate({:.5} {:.5})",
+            width as f64 / (max_coord.lon - min_coord.lon),
+            -1. * (height as f64) / (max_coord.lat - min_coord.lat),
+            -min_coord.lon,
+            -max_coord.lat,
+        ),
+    );
+
+    transform = transform
+        .add(road_group)
+        .add(river_group)
+        .add(lake_group)
+        .add(park_group);
+    document = document.add(transform);
+    svg::save(output, &document)
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "osmflat-render")]
+struct Args {
+    /// Osmflat archive
+    #[structopt(parse(from_os_str))]
+    osmflat_archive: PathBuf,
+
+    /// SVG filename to output
+    #[structopt(parse(from_os_str))]
+    output: PathBuf,
+
+    /// Width of the image
+    #[structopt(short = "w", long = "width", default_value = "800")]
+    width: u32,
+
+    /// Height of the image
+    #[structopt(short = "h", long = "height", default_value = "600")]
+    height: u32,
+}
+
+fn main() -> Result<(), Box<std::error::Error>> {
     let args = Args::from_args();
 
-    let storage = FileResourceStorage::new(args.flatdata_archive);
+    let storage = FileResourceStorage::new(args.osmflat_archive);
     let archive = osmflat::Osm::open(storage)?;
-    render(&archive, &args.output, args.flag_width)?;
+
+    let features = classify(archive.clone());
+    let archive_inner = archive.clone();
+    let classified_polylines = features.map(move |f| {
+        let cat = f.cat;
+        (f.into_polyline(archive_inner.clone()), cat)
+    });
+    render_svg(
+        archive,
+        classified_polylines,
+        args.output,
+        args.width,
+        args.height,
+    )?;
     Ok(())
 }


### PR DESCRIPTION
The idea is to do wireframe for ways + parks and waterways.

We should use this PR to discuss of API changes we want to introduce, to reduce the amount of boilerplate code necessary to use `osmflat`.

On top of my head:
* Iterator to loop / match through tags
* Maybe not use assert in `at()` and make it rusty by returning an Option?