### PR TITLE
Use sorted lookup tables instead of hashmaps

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -6,7 +6,7 @@ pub struct IdTable {
     num_ids: u32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct IdTableBuilder {
     // stored the same data as IdTable, but not yet sorted
     data: Vec<Vec<(u32, u32)>>,
@@ -15,10 +15,7 @@ pub struct IdTableBuilder {
 
 impl IdTableBuilder {
     pub fn new() -> Self {
-        Self {
-            data: Vec::new(),
-            next_id: 0,
-        }
+        Default::default()
     }
 
     /// Inserts an Id and returns a mapped index
@@ -38,9 +35,9 @@ impl IdTableBuilder {
         self.next_id += count;
     }
 
-    pub fn finalize(mut self) -> IdTable {
-        for mut x in &mut self.data {
-            x.sort();
+    pub fn build(mut self) -> IdTable {
+        for mut set in &mut self.data {
+            set.sort();
         }
 
         IdTable {
@@ -51,7 +48,7 @@ impl IdTableBuilder {
 }
 
 impl IdTable {
-    pub fn find(&self, x: u64) -> Option<u32> {
+    pub fn get(&self, x: u64) -> Option<u32> {
         let id_set = (x >> 32) as usize;
         if id_set > self.data.len() {
             return None;
@@ -75,14 +72,14 @@ mod test {
             builder.insert(*x);
         }
 
-        let lookup = builder.finalize();
+        let lookup = builder.build();
         for (pos, x) in data.iter().enumerate() {
-            let res = lookup.find(*x);
+            let res = lookup.get(*x);
             assert_eq!(res, Some(pos as u32));
         }
 
         for x in [0, 1, 2, 5, 6, 11, 12, 14].iter() {
-            let res = lookup.find(*x);
+            let res = lookup.get(*x);
             assert_eq!(res, None);
         }
     }
@@ -95,14 +92,14 @@ mod test {
             builder.insert(*x);
         }
 
-        let lookup = builder.finalize();
+        let lookup = builder.build();
         for (pos, x) in data.iter().enumerate() {
-            let res = lookup.find(*x);
+            let res = lookup.get(*x);
             assert_eq!(res, Some(pos as u32));
         }
 
         for x in [0, 3, (1_u64 << 33) + 1, (1_u64 << 34) + 1, 1_u64 << 35].iter() {
-            let res = lookup.find(*x);
+            let res = lookup.get(*x);
             assert_eq!(res, None);
         }
     }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,0 +1,109 @@
+/// Maps u64 integers to a consecutive range of ids
+#[derive(Debug)]
+pub struct IdTable {
+    // map u64 id x to u32 by storing a sorted mapping table for each value of x / 2^32
+    data: Vec<Vec<(u32, u32)>>,
+    num_ids: u32,
+}
+
+#[derive(Debug)]
+pub struct IdTableBuilder {
+    // stored the same data as IdTable, but not yet sorted
+    data: Vec<Vec<(u32, u32)>>,
+    next_id: u32,
+}
+
+impl IdTableBuilder {
+    pub fn new() -> Self {
+        Self {
+            data: Vec::new(),
+            next_id: 0,
+        }
+    }
+
+    /// Inserts an Id and returns a mapped index
+    pub fn insert(&mut self, x: u64) -> u32 {
+        let id_set = (x >> 32) as usize;
+        if self.data.len() <= id_set {
+            self.data.resize(id_set + 1, Vec::new());
+        }
+        self.data[id_set].push((x as u32, self.next_id));
+        let result = self.next_id;
+        self.next_id += 1;
+        result
+    }
+
+    /// Skips a few ids (e.g. to reserve them for other uses)
+    pub fn skip(&mut self, count: u32) {
+        self.next_id += count;
+    }
+
+    pub fn finalize(mut self) -> IdTable {
+        for mut x in &mut self.data {
+            x.sort();
+        }
+
+        IdTable {
+            data: self.data,
+            num_ids: self.next_id,
+        }
+    }
+}
+
+impl IdTable {
+    pub fn find(&self, x: u64) -> Option<u32> {
+        let id_set = (x >> 32) as usize;
+        if id_set > self.data.len() {
+            return None;
+        }
+        self.data[id_set]
+            .binary_search_by_key(&(x as u32), |item| item.0)
+            .ok()
+            .map(|pos| self.data[id_set][pos].1)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_mapping_of_small_ints() {
+        let mut builder = IdTableBuilder::new();
+        let data = [9, 8, 7, 4, 3, 10, 13];
+        for x in data.iter() {
+            builder.insert(*x);
+        }
+
+        let lookup = builder.finalize();
+        for (pos, x) in data.iter().enumerate() {
+            let res = lookup.find(*x);
+            assert_eq!(res, Some(pos as u32));
+        }
+
+        for x in [0, 1, 2, 5, 6, 11, 12, 14].iter() {
+            let res = lookup.find(*x);
+            assert_eq!(res, None);
+        }
+    }
+
+    #[test]
+    fn test_mapping_of_large_ints() {
+        let mut builder = IdTableBuilder::new();
+        let data = [2, 1, 1_u64 << 33, 1_u64 << 34];
+        for x in data.iter() {
+            builder.insert(*x);
+        }
+
+        let lookup = builder.finalize();
+        for (pos, x) in data.iter().enumerate() {
+            let res = lookup.find(*x);
+            assert_eq!(res, Some(pos as u32));
+        }
+
+        for x in [0, 3, (1_u64 << 33) + 1, (1_u64 << 34) + 1, 1_u64 << 35].iter() {
+            let res = lookup.find(*x);
+            assert_eq!(res, None);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,7 +245,7 @@ fn serialize_ways(
             for delta in &pbf_way.refs {
                 node_ref += delta;
                 let mut node_idx = nodes_index.grow()?;
-                let idx = match nodes_id_to_idx.find(node_ref as u64) {
+                let idx = match nodes_id_to_idx.get(node_ref as u64) {
                     Some(idx) => idx,
                     None => {
                         stats.num_unresolved_node_ids += 1;
@@ -274,7 +274,7 @@ fn build_relations_index<'a, F: Read + Seek, I: 'a + Iterator<Item = &'a BlockIn
             }
         }
     }
-    Ok(result.finalize())
+    Ok(result.build())
 }
 
 fn serialize_relations(
@@ -325,7 +325,7 @@ fn serialize_relations(
 
                 match member_type.unwrap() {
                     osmpbf::relation::MemberType::Node => {
-                        let idx = match nodes_id_to_idx.find(memid as u64) {
+                        let idx = match nodes_id_to_idx.get(memid as u64) {
                             Some(idx) => idx,
                             None => {
                                 stats.num_unresolved_node_ids += 1;
@@ -341,7 +341,7 @@ fn serialize_relations(
                         member.set_role_idx(stringtable.borrow_mut().insert(role));
                     }
                     osmpbf::relation::MemberType::Way => {
-                        let idx = match ways_id_to_idx.find(memid as u64) {
+                        let idx = match ways_id_to_idx.get(memid as u64) {
                             Some(idx) => idx,
                             None => {
                                 stats.num_unresolved_way_ids += 1;
@@ -357,7 +357,7 @@ fn serialize_relations(
                         member.set_role_idx(stringtable.borrow_mut().insert(role));
                     }
                     osmpbf::relation::MemberType::Relation => {
-                        let idx = match relations_id_to_idx.find(memid as u64) {
+                        let idx = match relations_id_to_idx.get(memid as u64) {
                             Some(idx) => idx,
                             None => {
                                 stats.num_unresolved_rel_ids += 1;
@@ -465,7 +465,7 @@ fn run() -> Result<(), Error> {
         pb.finish();
     }
     info!("Dense nodes converted.");
-    let nodes_id_to_idx = nodes_id_to_idx.finalize();
+    let nodes_id_to_idx = nodes_id_to_idx.build();
     info!("Dense index build.");
 
     // Serialize ways
@@ -501,7 +501,7 @@ fn run() -> Result<(), Error> {
         pb.finish();
     };
     info!("Ways converted.");
-    let ways_id_to_idx = ways_id_to_idx.finalize();
+    let ways_id_to_idx = ways_id_to_idx.build();
     info!("Way index build.");
 
     // Serialize relations


### PR DESCRIPTION
decreases memory consumption by ~50%