### PR TITLE
Switch references to u64 40 bits to allow parsing large datasets

### DIFF
--- a/examples/render.rs
+++ b/examples/render.rs
@@ -154,7 +154,7 @@ impl<'a> Iterator for NodesIterator<'a> {
     }
 }
 
-fn substring(strings: &str, start: u32) -> &str {
+fn substring(strings: &str, start: u64) -> &str {
     let start = start as usize;
     let end = strings[start..].find('\0').expect("invalid string");
     &strings[start..start + end]

--- a/src/flatdata/osm.flatdata
+++ b/src/flatdata/osm.flatdata
@@ -1,6 +1,6 @@
 namespace osm {
 
-// Max 40 bits values used to indicate null references
+// Max 40 bits value used to indicate null references
 const u64 INVALID_IDX = 0xFFFFFFFFFF;
 
 struct Header {

--- a/src/flatdata/osm.flatdata
+++ b/src/flatdata/osm.flatdata
@@ -1,6 +1,7 @@
 namespace osm {
 
-const u32 INVALID_IDX = 0;
+// Max 40 bits values used to indicate null references
+const u64 INVALID_IDX = 0xFFFFFFFFFF;
 
 struct Header {
     bbox_left: i64 : 64;
@@ -8,17 +9,17 @@ struct Header {
     bbox_top: i64 : 64;
     bbox_bottom: i64 : 64;
 
-    required_feature_first_idx: u32 : 32;
+    required_feature_first_idx: u64 : 40;
     required_features_size: u32 : 4;
-    optional_feature_first_idx: u32 : 32;
+    optional_feature_first_idx: u64 : 40;
     optional_features_size: u32 : 4;
 
-    writingprogram_idx: u32 : 32;
-    source_idx: u32 : 32;
+    writingprogram_idx: u64 : 40;
+    source_idx: u64 : 40;
 
     osmosis_replication_timestamp: i64 : 64;
     osmosis_replication_sequence_number: i64 : 64;
-    osmosis_replication_base_url_idx: u32 : 32;
+    osmosis_replication_base_url_idx: u64 : 40;
 }
 
 struct Info {
@@ -26,63 +27,63 @@ struct Info {
     timestamp: i64 : 64;
     changest: i64 : 64;
     uid: i32 : 32;
-    user_idx: u32 : 32;
+    user_idx: u64 : 40;
     visible: bool : 1;
 }
 
 struct Tag {
-    key_idx: u32 : 32;
-    value_idx: u32 : 32;
+    key_idx: u64 : 40;
+    value_idx: u64 : 40;
 }
 
 struct Node {
     id: i64 : 64;
     lat: i64 : 64;
     lon: i64 : 64;
-    tag_first_idx: u32 : 32;
-    info_idx: u32 : 32;
+    tag_first_idx: u64 : 40;
+    info_idx: u64 : 40;
 }
 
 /**
  * A struct indexing a node.
  */
 struct NodeIndex {
-    value: u32 : 32;
+    value: u64 : 40;
 }
 
 struct Way {
     id: i64 : 64;
-    tag_first_idx: u32 : 32;
-    ref_first_idx: u32 : 32;
-    info_idx: u32 : 32;
+    tag_first_idx: u64 : 40;
+    ref_first_idx: u64 : 40;
+    info_idx: u64 : 40;
 }
 
 /**
  * A struct indexing a tag.
  */
 struct TagIndex {
-    value: u32 : 32;
+    value: u64 : 40;
 }
 
 struct NodeMember {
-    node_idx: u32 : 32;
-    role_idx: u32 : 32;
+    node_idx: u64 : 40;
+    role_idx: u64 : 40;
 }
 
 struct WayMember {
-    way_idx: u32 : 32;
-    role_idx: u32 : 32;
+    way_idx: u64 : 40;
+    role_idx: u64 : 40;
 }
 
 struct RelationMember {
-    relation_idx: u32 : 32;
-    role_idx: u32 : 32;
+    relation_idx: u64 : 40;
+    role_idx: u64 : 40;
 }
 
 struct Relation {
     id: i64 : 64;
-    tag_first_idx: u32 : 32;
-    info_idx: u32 : 32;
+    tag_first_idx: u64 : 40;
+    info_idx: u64 : 40;
 }
 
 @bound_implicitly(Relations: relations, relation_members)
@@ -113,7 +114,7 @@ archive Osm {
     @explicit_reference( WayMember.role_idx, stringtable )
     @explicit_reference( RelationMember.relation_idx, relations )
     @explicit_reference( RelationMember.role_idx, stringtable )
-    relation_members: multivector<32, NodeMember, WayMember, RelationMember>;
+    relation_members: multivector<40, NodeMember, WayMember, RelationMember>;
 
     @explicit_reference( Tag.key_idx, stringtable )
     @explicit_reference( Tag.value_idx, stringtable )

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,16 +1,28 @@
 /// Maps u64 integers to a consecutive range of ids
 #[derive(Debug)]
 pub struct IdTable {
-    // map u64 id x to u32 by storing a sorted mapping table for each value of x / 2^32
-    data: Vec<Vec<(u32, u32)>>,
-    num_ids: u32,
+    // map u64 id x to u32 by storing a sorted mapping table for each value of x / 2^24
+    // each mapping entry (u64) represents (u24) id set (x % 2^24), and mapped id (u40)
+    data: Vec<Vec<u64>>,
+    num_ids: u64,
 }
 
 #[derive(Debug, Default)]
 pub struct IdTableBuilder {
     // stored the same data as IdTable, but not yet sorted
-    data: Vec<Vec<(u32, u32)>>,
-    next_id: u32,
+    data: Vec<Vec<u64>>,
+    next_id: u64,
+}
+
+// pack index compactly in 9 bytes: supports 1 trillion indices
+fn pack_index(x: (u32, u64)) -> u64 {
+    assert!(x.0 < (1_u32 << 24));
+    assert!(x.1 < (1_u64 << 40));
+    x.1 | ((x.0 as u64) << 40)
+}
+
+fn unpack_packed_index(x: u64) -> (u32, u64) {
+    ((x >> 40) as u32, x % (1_u64 << 40))
 }
 
 impl IdTableBuilder {
@@ -19,19 +31,19 @@ impl IdTableBuilder {
     }
 
     /// Inserts an Id and returns a mapped index
-    pub fn insert(&mut self, x: u64) -> u32 {
-        let id_set = (x >> 32) as usize;
+    pub fn insert(&mut self, x: u64) -> u64 {
+        let id_set = (x >> 24) as usize;
         if self.data.len() <= id_set {
             self.data.resize(id_set + 1, Vec::new());
         }
-        self.data[id_set].push((x as u32, self.next_id));
+        self.data[id_set].push(pack_index(((x % (1u64 << 24)) as u32, self.next_id.into())));
         let result = self.next_id;
         self.next_id += 1;
         result
     }
 
     /// Skips a few ids (e.g. to reserve them for other uses)
-    pub fn skip(&mut self, count: u32) {
+    pub fn skip(&mut self, count: u64) {
         self.next_id += count;
     }
 
@@ -48,15 +60,17 @@ impl IdTableBuilder {
 }
 
 impl IdTable {
-    pub fn get(&self, x: u64) -> Option<u32> {
-        let id_set = (x >> 32) as usize;
+    pub fn get(&self, x: u64) -> Option<u64> {
+        let id_set = (x >> 24) as usize;
         if id_set > self.data.len() {
             return None;
         }
         self.data[id_set]
-            .binary_search_by_key(&(x as u32), |item| item.0)
+            .binary_search_by_key(&((x % (1u64 << 24)) as u32), |item| {
+                unpack_packed_index(*item).0
+            })
             .ok()
-            .map(|pos| self.data[id_set][pos].1)
+            .map(|pos| unpack_packed_index(self.data[id_set][pos]).1)
     }
 }
 
@@ -75,7 +89,7 @@ mod test {
         let lookup = builder.build();
         for (pos, x) in data.iter().enumerate() {
             let res = lookup.get(*x);
-            assert_eq!(res, Some(pos as u32));
+            assert_eq!(res, Some(pos as u64));
         }
 
         for x in [0, 1, 2, 5, 6, 11, 12, 14].iter() {
@@ -95,7 +109,28 @@ mod test {
         let lookup = builder.build();
         for (pos, x) in data.iter().enumerate() {
             let res = lookup.get(*x);
-            assert_eq!(res, Some(pos as u32));
+            assert_eq!(res, Some(pos as u64));
+        }
+
+        for x in [0, 3, (1_u64 << 33) + 1, (1_u64 << 34) + 1, 1_u64 << 35].iter() {
+            let res = lookup.get(*x);
+            assert_eq!(res, None);
+        }
+    }
+
+    #[test]
+    fn test_large_indices() {
+        let mut builder = IdTableBuilder::new();
+        builder.skip(1u64 << 33);
+        let data = [2, 1, 1_u64 << 33, 1_u64 << 34];
+        for x in data.iter() {
+            builder.insert(*x);
+        }
+
+        let lookup = builder.build();
+        for (pos, x) in data.iter().enumerate() {
+            let res = lookup.get(*x);
+            assert_eq!(res, Some((pos as u64) + (1u64 << 33)));
         }
 
         for x in [0, 3, (1_u64 << 33) + 1, (1_u64 << 34) + 1, 1_u64 << 35].iter() {

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -14,7 +14,7 @@ pub struct IdTableBuilder {
     next_id: u64,
 }
 
-// pack index compactly in 9 bytes: supports 1 trillion indices
+// pack index compactly in 8 bytes: supports 1 trillion indices
 fn pack_index(x: (u32, u64)) -> u64 {
     assert!(x.0 < (1_u32 << 24));
     assert!(x.1 < (1_u64 << 40));

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn serialize_header(
 struct TagSerializer<'a> {
     tags: flatdata::ExternalVector<'a, osmflat::Tag>,
     tags_index: flatdata::ExternalVector<'a, osmflat::TagIndex>,
-    dedup: HashMap<(u32, u32), u32>, // deduplication table: (key_idx, val_idx) -> pos
+    dedup: HashMap<(u64, u64), u64>, // deduplication table: (key_idx, val_idx) -> pos
 }
 
 impl<'a> TagSerializer<'a> {
@@ -112,11 +112,11 @@ impl<'a> TagSerializer<'a> {
         })
     }
 
-    fn serialize(&mut self, key_idx: u32, val_idx: u32) -> Result<(), Error> {
+    fn serialize(&mut self, key_idx: u64, val_idx: u64) -> Result<(), Error> {
         let idx = match self.dedup.entry((key_idx, val_idx)) {
             hash_map::Entry::Occupied(entry) => *entry.get(),
             hash_map::Entry::Vacant(entry) => {
-                let idx = self.tags.len() as u32;
+                let idx = self.tags.len() as u64;
                 let mut tag = self.tags.grow()?;
                 tag.set_key_idx(key_idx);
                 tag.set_value_idx(val_idx);
@@ -131,8 +131,8 @@ impl<'a> TagSerializer<'a> {
         Ok(())
     }
 
-    fn next_index(&self) -> u32 {
-        self.tags_index.len() as u32
+    fn next_index(&self) -> u64 {
+        self.tags_index.len() as u64
     }
 
     fn close(self) {
@@ -150,7 +150,7 @@ impl<'a> TagSerializer<'a> {
 fn add_string_table(
     pbf_stringtable: &osmpbf::StringTable,
     stringtable: &mut StringTable,
-) -> Result<Vec<u32>, Error> {
+) -> Result<Vec<u64>, Error> {
     let mut result = Vec::new();
     for x in &pbf_stringtable.s {
         let string = str::from_utf8(&x)?;
@@ -243,7 +243,7 @@ fn serialize_ways(
 
             // TODO: serialize info
 
-            way.set_ref_first_idx(nodes_index.len() as u32);
+            way.set_ref_first_idx(nodes_index.len() as u64);
             let mut node_ref = 0;
             for delta in &pbf_way.refs {
                 node_ref += delta;
@@ -287,7 +287,7 @@ fn serialize_relations(
     relations_id_to_idx: &ids::IdTable,
     stringtable: &mut StringTable,
     relations: &mut flatdata::ExternalVector<osmflat::Relation>,
-    relation_members: &mut flatdata::MultiVector<osmflat::IndexType32, osmflat::RelationMembers>,
+    relation_members: &mut flatdata::MultiVector<osmflat::IndexType40, osmflat::RelationMembers>,
     tags: &mut TagSerializer,
 ) -> Result<Stats, Error> {
     let mut stats = Stats::default();
@@ -496,7 +496,7 @@ fn run() -> Result<(), Error> {
         {
             let mut sentinel = ways.grow()?;
             sentinel.set_tag_first_idx(tags.next_index());
-            sentinel.set_ref_first_idx(nodes_index.len() as u32);
+            sentinel.set_ref_first_idx(nodes_index.len() as u64);
         }
         ways.close()?;
         pb.finish();

--- a/src/osmflat.rs
+++ b/src/osmflat.rs
@@ -492,7 +492,7 @@ archive Osm
     }
 }
 
-// Max 40 bits values used to indicate null references
+// Max 40 bits value used to indicate null references
 pub const INVALID_IDX: u64 = 1099511627775;
 
 define_struct!(

--- a/src/osmflat.rs
+++ b/src/osmflat.rs
@@ -10,15 +10,15 @@ struct Header
     bbox_right : i64 : 64;
     bbox_top : i64 : 64;
     bbox_bottom : i64 : 64;
-    required_feature_first_idx : u32 : 32;
+    required_feature_first_idx : u64 : 40;
     required_features_size : u32 : 4;
-    optional_feature_first_idx : u32 : 32;
+    optional_feature_first_idx : u64 : 40;
     optional_features_size : u32 : 4;
-    writingprogram_idx : u32 : 32;
-    source_idx : u32 : 32;
+    writingprogram_idx : u64 : 40;
+    source_idx : u64 : 40;
     osmosis_replication_timestamp : i64 : 64;
     osmosis_replication_sequence_number : i64 : 64;
-    osmosis_replication_base_url_idx : u32 : 32;
+    osmosis_replication_base_url_idx : u64 : 40;
 }
 }
 
@@ -30,7 +30,7 @@ struct Info
     timestamp : i64 : 64;
     changest : i64 : 64;
     uid : i32 : 32;
-    user_idx : u32 : 32;
+    user_idx : u64 : 40;
     visible : bool : 1;
 }
 }
@@ -39,8 +39,8 @@ struct Info
         pub const TAG: &str = r#"namespace osm {
 struct Tag
 {
-    key_idx : u32 : 32;
-    value_idx : u32 : 32;
+    key_idx : u64 : 40;
+    value_idx : u64 : 40;
 }
 }
 
@@ -51,8 +51,8 @@ struct Node
     id : i64 : 64;
     lat : i64 : 64;
     lon : i64 : 64;
-    tag_first_idx : u32 : 32;
-    info_idx : u32 : 32;
+    tag_first_idx : u64 : 40;
+    info_idx : u64 : 40;
 }
 }
 
@@ -60,7 +60,7 @@ struct Node
         pub const NODE_INDEX: &str = r#"namespace osm {
 struct NodeIndex
 {
-    value : u32 : 32;
+    value : u64 : 40;
 }
 }
 
@@ -69,9 +69,9 @@ struct NodeIndex
 struct Way
 {
     id : i64 : 64;
-    tag_first_idx : u32 : 32;
-    ref_first_idx : u32 : 32;
-    info_idx : u32 : 32;
+    tag_first_idx : u64 : 40;
+    ref_first_idx : u64 : 40;
+    info_idx : u64 : 40;
 }
 }
 
@@ -79,7 +79,7 @@ struct Way
         pub const TAG_INDEX: &str = r#"namespace osm {
 struct TagIndex
 {
-    value : u32 : 32;
+    value : u64 : 40;
 }
 }
 
@@ -87,8 +87,8 @@ struct TagIndex
         pub const NODE_MEMBER: &str = r#"namespace osm {
 struct NodeMember
 {
-    node_idx : u32 : 32;
-    role_idx : u32 : 32;
+    node_idx : u64 : 40;
+    role_idx : u64 : 40;
 }
 }
 
@@ -96,8 +96,8 @@ struct NodeMember
         pub const WAY_MEMBER: &str = r#"namespace osm {
 struct WayMember
 {
-    way_idx : u32 : 32;
-    role_idx : u32 : 32;
+    way_idx : u64 : 40;
+    role_idx : u64 : 40;
 }
 }
 
@@ -105,8 +105,8 @@ struct WayMember
         pub const RELATION_MEMBER: &str = r#"namespace osm {
 struct RelationMember
 {
-    relation_idx : u32 : 32;
-    role_idx : u32 : 32;
+    relation_idx : u64 : 40;
+    role_idx : u64 : 40;
 }
 }
 
@@ -115,13 +115,13 @@ struct RelationMember
 struct Relation
 {
     id : i64 : 64;
-    tag_first_idx : u32 : 32;
-    info_idx : u32 : 32;
+    tag_first_idx : u64 : 40;
+    info_idx : u64 : 40;
 }
 }
 
 "#;
-        pub const INDEX_TYPE32: &str = r#""#;
+        pub const INDEX_TYPE40: &str = r#""#;
         pub const OSM: &str = r#"namespace osm {
 struct Header
 {
@@ -129,15 +129,15 @@ struct Header
     bbox_right : i64 : 64;
     bbox_top : i64 : 64;
     bbox_bottom : i64 : 64;
-    required_feature_first_idx : u32 : 32;
+    required_feature_first_idx : u64 : 40;
     required_features_size : u32 : 4;
-    optional_feature_first_idx : u32 : 32;
+    optional_feature_first_idx : u64 : 40;
     optional_features_size : u32 : 4;
-    writingprogram_idx : u32 : 32;
-    source_idx : u32 : 32;
+    writingprogram_idx : u64 : 40;
+    source_idx : u64 : 40;
     osmosis_replication_timestamp : i64 : 64;
     osmosis_replication_sequence_number : i64 : 64;
-    osmosis_replication_base_url_idx : u32 : 32;
+    osmosis_replication_base_url_idx : u64 : 40;
 }
 }
 
@@ -147,8 +147,8 @@ struct Node
     id : i64 : 64;
     lat : i64 : 64;
     lon : i64 : 64;
-    tag_first_idx : u32 : 32;
-    info_idx : u32 : 32;
+    tag_first_idx : u64 : 40;
+    info_idx : u64 : 40;
 }
 }
 
@@ -156,9 +156,9 @@ namespace osm {
 struct Way
 {
     id : i64 : 64;
-    tag_first_idx : u32 : 32;
-    ref_first_idx : u32 : 32;
-    info_idx : u32 : 32;
+    tag_first_idx : u64 : 40;
+    ref_first_idx : u64 : 40;
+    info_idx : u64 : 40;
 }
 }
 
@@ -166,40 +166,40 @@ namespace osm {
 struct Relation
 {
     id : i64 : 64;
-    tag_first_idx : u32 : 32;
-    info_idx : u32 : 32;
+    tag_first_idx : u64 : 40;
+    info_idx : u64 : 40;
 }
 }
 
 namespace osm {
 struct NodeMember
 {
-    node_idx : u32 : 32;
-    role_idx : u32 : 32;
+    node_idx : u64 : 40;
+    role_idx : u64 : 40;
 }
 }
 
 namespace osm {
 struct WayMember
 {
-    way_idx : u32 : 32;
-    role_idx : u32 : 32;
+    way_idx : u64 : 40;
+    role_idx : u64 : 40;
 }
 }
 
 namespace osm {
 struct RelationMember
 {
-    relation_idx : u32 : 32;
-    role_idx : u32 : 32;
+    relation_idx : u64 : 40;
+    role_idx : u64 : 40;
 }
 }
 
 namespace osm {
 struct Tag
 {
-    key_idx : u32 : 32;
-    value_idx : u32 : 32;
+    key_idx : u64 : 40;
+    value_idx : u64 : 40;
 }
 }
 
@@ -210,7 +210,7 @@ struct Info
     timestamp : i64 : 64;
     changest : i64 : 64;
     uid : i32 : 32;
-    user_idx : u32 : 32;
+    user_idx : u64 : 40;
     visible : bool : 1;
 }
 }
@@ -218,19 +218,19 @@ struct Info
 namespace osm {
 struct TagIndex
 {
-    value : u32 : 32;
+    value : u64 : 40;
 }
 }
 
 namespace osm {
 struct NodeIndex
 {
-    value : u32 : 32;
+    value : u64 : 40;
 }
 }
 
 namespace osm {
-const u32 INVALID_IDX = 0;
+const u64 INVALID_IDX = 1099511627775;
 }
 
 namespace osm {
@@ -259,7 +259,7 @@ archive Osm
     @explicit_reference( .osm.WayMember.role_idx, .osm.Osm.stringtable )
     @explicit_reference( .osm.RelationMember.relation_idx, .osm.Osm.relations )
     @explicit_reference( .osm.RelationMember.role_idx, .osm.Osm.stringtable )
-    relation_members : multivector< 32, .osm.NodeMember, .osm.WayMember, .osm.RelationMember >;
+    relation_members : multivector< 40, .osm.NodeMember, .osm.WayMember, .osm.RelationMember >;
     @explicit_reference( .osm.Tag.key_idx, .osm.Osm.stringtable )
     @explicit_reference( .osm.Tag.value_idx, .osm.Osm.stringtable )
     tags : vector< .osm.Tag >;
@@ -285,15 +285,15 @@ struct Header
     bbox_right : i64 : 64;
     bbox_top : i64 : 64;
     bbox_bottom : i64 : 64;
-    required_feature_first_idx : u32 : 32;
+    required_feature_first_idx : u64 : 40;
     required_features_size : u32 : 4;
-    optional_feature_first_idx : u32 : 32;
+    optional_feature_first_idx : u64 : 40;
     optional_features_size : u32 : 4;
-    writingprogram_idx : u32 : 32;
-    source_idx : u32 : 32;
+    writingprogram_idx : u64 : 40;
+    source_idx : u64 : 40;
     osmosis_replication_timestamp : i64 : 64;
     osmosis_replication_sequence_number : i64 : 64;
-    osmosis_replication_base_url_idx : u32 : 32;
+    osmosis_replication_base_url_idx : u64 : 40;
 }
 }
 
@@ -316,8 +316,8 @@ struct Node
     id : i64 : 64;
     lat : i64 : 64;
     lon : i64 : 64;
-    tag_first_idx : u32 : 32;
-    info_idx : u32 : 32;
+    tag_first_idx : u64 : 40;
+    info_idx : u64 : 40;
 }
 }
 
@@ -335,9 +335,9 @@ pub const WAYS: &str = r#"namespace osm {
 struct Way
 {
     id : i64 : 64;
-    tag_first_idx : u32 : 32;
-    ref_first_idx : u32 : 32;
-    info_idx : u32 : 32;
+    tag_first_idx : u64 : 40;
+    ref_first_idx : u64 : 40;
+    info_idx : u64 : 40;
 }
 }
 
@@ -356,8 +356,8 @@ pub const RELATIONS: &str = r#"namespace osm {
 struct Relation
 {
     id : i64 : 64;
-    tag_first_idx : u32 : 32;
-    info_idx : u32 : 32;
+    tag_first_idx : u64 : 40;
+    info_idx : u64 : 40;
 }
 }
 
@@ -374,24 +374,24 @@ archive Osm
 pub const RELATION_MEMBERS: &str = r#"namespace osm {
 struct NodeMember
 {
-    node_idx : u32 : 32;
-    role_idx : u32 : 32;
+    node_idx : u64 : 40;
+    role_idx : u64 : 40;
 }
 }
 
 namespace osm {
 struct WayMember
 {
-    way_idx : u32 : 32;
-    role_idx : u32 : 32;
+    way_idx : u64 : 40;
+    role_idx : u64 : 40;
 }
 }
 
 namespace osm {
 struct RelationMember
 {
-    relation_idx : u32 : 32;
-    role_idx : u32 : 32;
+    relation_idx : u64 : 40;
+    role_idx : u64 : 40;
 }
 }
 
@@ -404,7 +404,7 @@ archive Osm
     @explicit_reference( .osm.WayMember.role_idx, .osm.Osm.stringtable )
     @explicit_reference( .osm.RelationMember.relation_idx, .osm.Osm.relations )
     @explicit_reference( .osm.RelationMember.role_idx, .osm.Osm.stringtable )
-    relation_members : multivector< 32, .osm.NodeMember, .osm.WayMember, .osm.RelationMember >;
+    relation_members : multivector< 40, .osm.NodeMember, .osm.WayMember, .osm.RelationMember >;
 }
 }
 
@@ -412,8 +412,8 @@ archive Osm
 pub const TAGS: &str = r#"namespace osm {
 struct Tag
 {
-    key_idx : u32 : 32;
-    value_idx : u32 : 32;
+    key_idx : u64 : 40;
+    value_idx : u64 : 40;
 }
 }
 
@@ -434,7 +434,7 @@ struct Info
     timestamp : i64 : 64;
     changest : i64 : 64;
     uid : i32 : 32;
-    user_idx : u32 : 32;
+    user_idx : u64 : 40;
     visible : bool : 1;
 }
 }
@@ -451,7 +451,7 @@ archive Osm
 pub const TAGS_INDEX: &str = r#"namespace osm {
 struct TagIndex
 {
-    value : u32 : 32;
+    value : u64 : 40;
 }
 }
 
@@ -467,7 +467,7 @@ archive Osm
 pub const NODES_INDEX: &str = r#"namespace osm {
 struct NodeIndex
 {
-    value : u32 : 32;
+    value : u64 : 40;
 }
 }
 
@@ -492,27 +492,28 @@ archive Osm
     }
 }
 
-pub const INVALID_IDX: u32 = 0;
+// Max 40 bits values used to indicate null references
+pub const INVALID_IDX: u64 = 1099511627775;
 
 define_struct!(
     Header,
     RefHeader,
     RefMutHeader,
     schema::structs::HEADER,
-    69,
+    74,
     (bbox_left, set_bbox_left, i64, 0, 64),
     (bbox_right, set_bbox_right, i64, 64, 64),
     (bbox_top, set_bbox_top, i64, 128, 64),
     (bbox_bottom, set_bbox_bottom, i64, 192, 64),
-    (required_feature_first_idx, set_required_feature_first_idx, u32, 256, 32),
-    (required_features_size, set_required_features_size, u32, 288, 4),
-    (optional_feature_first_idx, set_optional_feature_first_idx, u32, 292, 32),
-    (optional_features_size, set_optional_features_size, u32, 324, 4),
-    (writingprogram_idx, set_writingprogram_idx, u32, 328, 32),
-    (source_idx, set_source_idx, u32, 360, 32),
-    (osmosis_replication_timestamp, set_osmosis_replication_timestamp, i64, 392, 64),
-    (osmosis_replication_sequence_number, set_osmosis_replication_sequence_number, i64, 456, 64),
-    (osmosis_replication_base_url_idx, set_osmosis_replication_base_url_idx, u32, 520, 32));
+    (required_feature_first_idx, set_required_feature_first_idx, u64, 256, 40),
+    (required_features_size, set_required_features_size, u32, 296, 4),
+    (optional_feature_first_idx, set_optional_feature_first_idx, u64, 300, 40),
+    (optional_features_size, set_optional_features_size, u32, 340, 4),
+    (writingprogram_idx, set_writingprogram_idx, u64, 344, 40),
+    (source_idx, set_source_idx, u64, 384, 40),
+    (osmosis_replication_timestamp, set_osmosis_replication_timestamp, i64, 424, 64),
+    (osmosis_replication_sequence_number, set_osmosis_replication_sequence_number, i64, 488, 64),
+    (osmosis_replication_base_url_idx, set_osmosis_replication_base_url_idx, u64, 552, 40));
 
 
 define_struct!(
@@ -520,13 +521,13 @@ define_struct!(
     RefInfo,
     RefMutInfo,
     schema::structs::INFO,
-    29,
+    30,
     (version, set_version, i32, 0, 32),
     (timestamp, set_timestamp, i64, 32, 64),
     (changest, set_changest, i64, 96, 64),
     (uid, set_uid, i32, 160, 32),
-    (user_idx, set_user_idx, u32, 192, 32),
-    (visible, set_visible, bool, 224, 1));
+    (user_idx, set_user_idx, u64, 192, 40),
+    (visible, set_visible, bool, 232, 1));
 
 
 define_struct!(
@@ -534,9 +535,9 @@ define_struct!(
     RefTag,
     RefMutTag,
     schema::structs::TAG,
-    8,
-    (key_idx, set_key_idx, u32, 0, 32),
-    (value_idx, set_value_idx, u32, 32, 32));
+    10,
+    (key_idx, set_key_idx, u64, 0, 40),
+    (value_idx, set_value_idx, u64, 40, 40));
 
 
 define_struct!(
@@ -544,12 +545,12 @@ define_struct!(
     RefNode,
     RefMutNode,
     schema::structs::NODE,
-    32,
+    34,
     (id, set_id, i64, 0, 64),
     (lat, set_lat, i64, 64, 64),
     (lon, set_lon, i64, 128, 64),
-    (tag_first_idx, set_tag_first_idx, u32, 192, 32),
-    (info_idx, set_info_idx, u32, 224, 32));
+    (tag_first_idx, set_tag_first_idx, u64, 192, 40),
+    (info_idx, set_info_idx, u64, 232, 40));
 
 /// A struct indexing a node.
 define_struct!(
@@ -557,8 +558,8 @@ define_struct!(
     RefNodeIndex,
     RefMutNodeIndex,
     schema::structs::NODE_INDEX,
-    4,
-    (value, set_value, u32, 0, 32));
+    5,
+    (value, set_value, u64, 0, 40));
 
 
 define_struct!(
@@ -566,11 +567,11 @@ define_struct!(
     RefWay,
     RefMutWay,
     schema::structs::WAY,
-    20,
+    23,
     (id, set_id, i64, 0, 64),
-    (tag_first_idx, set_tag_first_idx, u32, 64, 32),
-    (ref_first_idx, set_ref_first_idx, u32, 96, 32),
-    (info_idx, set_info_idx, u32, 128, 32));
+    (tag_first_idx, set_tag_first_idx, u64, 64, 40),
+    (ref_first_idx, set_ref_first_idx, u64, 104, 40),
+    (info_idx, set_info_idx, u64, 144, 40));
 
 /// A struct indexing a tag.
 define_struct!(
@@ -578,8 +579,8 @@ define_struct!(
     RefTagIndex,
     RefMutTagIndex,
     schema::structs::TAG_INDEX,
-    4,
-    (value, set_value, u32, 0, 32));
+    5,
+    (value, set_value, u64, 0, 40));
 
 
 define_struct!(
@@ -587,9 +588,9 @@ define_struct!(
     RefNodeMember,
     RefMutNodeMember,
     schema::structs::NODE_MEMBER,
-    8,
-    (node_idx, set_node_idx, u32, 0, 32),
-    (role_idx, set_role_idx, u32, 32, 32));
+    10,
+    (node_idx, set_node_idx, u64, 0, 40),
+    (role_idx, set_role_idx, u64, 40, 40));
 
 
 define_struct!(
@@ -597,9 +598,9 @@ define_struct!(
     RefWayMember,
     RefMutWayMember,
     schema::structs::WAY_MEMBER,
-    8,
-    (way_idx, set_way_idx, u32, 0, 32),
-    (role_idx, set_role_idx, u32, 32, 32));
+    10,
+    (way_idx, set_way_idx, u64, 0, 40),
+    (role_idx, set_role_idx, u64, 40, 40));
 
 
 define_struct!(
@@ -607,9 +608,9 @@ define_struct!(
     RefRelationMember,
     RefMutRelationMember,
     schema::structs::RELATION_MEMBER,
-    8,
-    (relation_idx, set_relation_idx, u32, 0, 32),
-    (role_idx, set_role_idx, u32, 32, 32));
+    10,
+    (relation_idx, set_relation_idx, u64, 0, 40),
+    (role_idx, set_role_idx, u64, 40, 40));
 
 
 define_struct!(
@@ -617,25 +618,25 @@ define_struct!(
     RefRelation,
     RefMutRelation,
     schema::structs::RELATION,
-    16,
+    18,
     (id, set_id, i64, 0, 64),
-    (tag_first_idx, set_tag_first_idx, u32, 64, 32),
-    (info_idx, set_info_idx, u32, 96, 32));
+    (tag_first_idx, set_tag_first_idx, u64, 64, 40),
+    (info_idx, set_info_idx, u64, 104, 40));
 
 /// Builtin type to for MultiVector index
 define_index!(
-    IndexType32,
-    RefIndexType32,
-    RefMutIndexType32,
-    schema::structs::INDEX_TYPE32,
-    4,
-    32
+    IndexType40,
+    RefIndexType40,
+    RefMutIndexType40,
+    schema::structs::INDEX_TYPE40,
+    5,
+    40
 );
 
 
 /// Builtin union type of NodeMember, WayMember, RelationMember.
 define_variadic_struct!(RelationMembers, RefRelationMembers, BuilderRelationMembers,
-    IndexType32,
+    IndexType40,
     0 => (NodeMember, add_node_member),
     1 => (WayMember, add_way_member),
     2 => (RelationMember, add_relation_member));
@@ -663,7 +664,7 @@ define_archive!(Osm, OsmBuilder,
     // multivector resources
     (relation_members, start_relation_members,
         RelationMembers, schema::resources::osm::RELATION_MEMBERS,
-        relation_members_index, IndexType32, false);
+        relation_members_index, IndexType40, false);
     // raw data resources
     (stringtable, set_stringtable,
         schema::resources::osm::STRINGTABLE, false);


### PR DESCRIPTION
Allows compiling the world:
Converted:
  nodes:        4865707327
  ways:         542103143
  relations:    6325585
Unresolved ids:
  nodes:        0
  ways:         0
  relations:    0
3296.77s real, 2993.31s user, 159.79s sys, 57005004Kb Max RSS
