### PR TITLE
Re-export flatadata Archive and FileResourceStorage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #[macro_use]
 extern crate flatdata;
 
+// re-export what is needed from flatdata to use osmflat
+pub use flatdata::{Archive, FileResourceStorage};
+
 mod osmflat;
 
 pub use osmflat::*;


### PR DESCRIPTION
When a create depends on `osmflat`, you probably don't want to add a direct dependency to `flatdata` just so you open a `flatdata::Archive`.