### PR TITLE
Fix dead code warnings.

### DIFF
--- a/osmflat/examples/debug.rs
+++ b/osmflat/examples/debug.rs
@@ -33,42 +33,63 @@ impl fmt::Debug for FixedI64 {
 
 #[derive(Debug)]
 struct Header<'ar> {
+    #[allow(unused)]
     bbox: (FixedI64, FixedI64, FixedI64, FixedI64),
+    #[allow(unused)]
     required_features: Vec<&'ar str>,
+    #[allow(unused)]
     optional_features: Vec<&'ar str>,
+    #[allow(unused)]
     writingprogram: &'ar str,
+    #[allow(unused)]
     source: &'ar str,
+    #[allow(unused)]
     osmosis_replication_timestamp: i64,
+    #[allow(unused)]
     osmosis_replication_sequence_number: i64,
+    #[allow(unused)]
     osmosis_replication_base_url: &'ar str,
 }
 
 #[derive(Debug)]
 struct Node<'ar> {
+    #[allow(unused)]
     id: i64,
+    #[allow(unused)]
     lat: FixedI64,
+    #[allow(unused)]
     lon: FixedI64,
+    #[allow(unused)]
     tags: Vec<(&'ar str, &'ar str)>,
 }
 
 #[derive(Debug)]
 struct Way<'ar> {
+    #[allow(unused)]
     id: i64,
+    #[allow(unused)]
     tags: Vec<(&'ar str, &'ar str)>,
+    #[allow(unused)]
     nodes: Vec<Option<u64>>,
 }
 
 #[derive(Debug)]
 struct Relation<'ar> {
+    #[allow(unused)]
     id: i64,
+    #[allow(unused)]
     tags: Vec<(&'ar str, &'ar str)>,
+    #[allow(unused)]
     members: Vec<Member<'ar>>,
 }
 
 #[derive(Debug)]
 struct Member<'ar> {
+    #[allow(unused)]
     type_: Type,
+    #[allow(unused)]
     idx: Option<u64>,
+    #[allow(unused)]
     role: &'ar str,
 }
 

--- a/osmflatc/src/ids.rs
+++ b/osmflatc/src/ids.rs
@@ -6,7 +6,6 @@ pub struct IdTable {
     // map u64 id x to u32 by storing a sorted mapping table for each value of x / 2^24
     // each mapping entry (u64) represents (u24) id set (x % 2^24), and mapped id (u40)
     data: Vec<Vec<u64>>,
-    num_ids: u64,
 }
 
 #[derive(Debug, Default)]
@@ -47,10 +46,7 @@ impl IdTableBuilder {
     pub fn build(mut self) -> IdTable {
         self.data.par_iter_mut().for_each(|x| x.par_sort_unstable());
 
-        IdTable {
-            data: self.data,
-            num_ids: self.next_id,
-        }
+        IdTable { data: self.data }
     }
 }
 


### PR DESCRIPTION
The dead code analysis is more strict now. In particular, fields
are considered unused, even if they are used in derived code, like
Debug derive.

Cf. https://github.com/rust-lang/rust/issues/88900