### PR TITLE
Make osmflat more compact (especially when compressed)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
 
 [patch.crates-io]
 osmflat = { path = "osmflat" }
-
-[profile.release]
-debug = true

--- a/flatdata/osm.flatdata
+++ b/flatdata/osm.flatdata
@@ -9,31 +9,23 @@ namespace osm {
 const u64 INVALID_IDX = 0xFFFFFFFFFF;
 
 /**
- * All coordinate are scaled by this constant to convert them to integers.
- */
-const u64 COORD_SCALE = 1000000000;
-
-/**
  * Metadata attached to the archive.
  */
 struct Header {
-    /// Bounding box (min longitude scaled with `COORD_SCALE`)
-    bbox_left: i64 : 40;
-    /// Bounding box (max longitude scaled with `COORD_SCALE`)
-    bbox_right: i64 : 40;
-    /// Bounding box (max latitude scaled with `COORD_SCALE`)
-    bbox_top: i64 : 40;
-    /// Bounding box (min latitude scaled with `COORD_SCALE`)
-    bbox_bottom: i64 : 40;
+    /**
+     * All coordinates in this archive are scaled by this constant
+     * To get the original degree-based coordinate back compute (latitude/coord_scale,longitude/coord_scale)
+     */
+    coord_scale: i32;
 
-    /// Reference to the first required feature in `stringtable`.
-    required_feature_first_idx: u64 : 40;
-    /// Number of required features.
-    required_features_size: u32 : 4;
-    /// Reference to the first optional feature in `stringtable`.
-    optional_feature_first_idx: u64 : 40;
-    /// Number of optional features.
-    optional_features_size: u32 : 4;
+    /// Bounding box (min longitude scaled with `header.coord_scale`)
+    bbox_left: i32 : 32;
+    /// Bounding box (max longitude scaled with `header.coord_scale`)
+    bbox_right: i32 : 32;
+    /// Bounding box (max latitude scaled with `header.coord_scale`)
+    bbox_top: i32 : 32;
+    /// Bounding box (min latitude scaled with `header.coord_scale`)
+    bbox_bottom: i32 : 32;
 
     /// Writing program used to write the data (reference to `stringtable`).
     writingprogram_idx: u64 : 40;
@@ -46,17 +38,17 @@ struct Header {
      *
      * [`state.txt`]: https://wiki.openstreetmap.org/wiki/Planet.osm/diffs#Minute.2C_Hour.2C_and_Day_Files_Organisation
      */
-    osmosis_replication_timestamp: i64 : 64;
+    replication_timestamp: i64 : 64;
     /**
      * Replication sequence number (`sequenceNumber` from [`state.txt`]).
      *
      * [`state.txt`]: https://wiki.openstreetmap.org/wiki/Planet.osm/diffs#Minute.2C_Hour.2C_and_Day_Files_Organisation
      */
-    osmosis_replication_sequence_number: i64 : 64;
+    replication_sequence_number: i64 : 64;
     /**
      * Replication base URL (reference to `stringtable`).
      */
-    osmosis_replication_base_url_idx: u64 : 40;
+    replication_base_url_idx: u64 : 40;
 }
 
 /**
@@ -77,12 +69,10 @@ struct Tag {
  * See <https://wiki.openstreetmap.org/wiki/Node>.
  */
 struct Node {
-    /// Unique node ID
-    id: i64 : 40;
-    /// Latitude (scaled with `COORD_SCALE`).
-    lat: i64 : 40;
-    /// Longitude (scaled with `COORD_SCALE`).
-    lon: i64 : 40;
+    /// Latitude (scaled with `header.coord_scale`).
+    lat: i32 : 32;
+    /// Longitude (scaled with `header.coord_scale`).
+    lon: i32 : 32;
     /**
      * Range of tags attached to this node.
      *
@@ -107,8 +97,6 @@ struct NodeIndex {
  * See <https://wiki.openstreetmap.org/wiki/Way>.
  */
 struct Way {
-    /// Unique ID of the way.
-    id: i64 : 40;
     /**
      * Range of tags attached to this node.
      *
@@ -178,8 +166,6 @@ struct RelationMember {
  * See <https://wiki.openstreetmap.org/wiki/Relation>.
  */
 struct Relation {
-    /// Unique ID of the relation.
-    id: i64 : 40;
     /**
      * Range of tags attached to this relation.
      *
@@ -187,6 +173,33 @@ struct Relation {
      */
     @range(tags)
     tag_first_idx: u64 : 40;
+}
+
+struct Id {
+    value: u64 : 40;
+}
+
+/**
+ * An optional sub-archive storing the original OSM ids of nodes, ways, and relations
+ */
+archive Ids {
+    /**
+     * List of OSM ids of all nodes in the parent archive
+     * nodes[i] has its id stored in ids.nodes[i]
+     */
+    nodes: vector< Id >;
+
+    /**
+     * List of OSM ids of all ways in the parent archive
+     * ways[i] has its id stored in ids.ways[i]
+     */
+    ways: vector< Id >;
+
+    /**
+     * List of OSM ids of all relations in the parent archive
+     * relations[i] has its id stored in ids.relations[i]
+     */
+    relations: vector< Id >;
 }
 
 /**
@@ -215,11 +228,9 @@ archive Osm {
     /**
      * Header which contains the metadata attached to the archive.
      */
-    @explicit_reference( Header.required_feature_first_idx, stringtable )
-    @explicit_reference( Header.optional_feature_first_idx, stringtable )
     @explicit_reference( Header.writingprogram_idx, stringtable )
     @explicit_reference( Header.source_idx, stringtable )
-    @explicit_reference( Header.osmosis_replication_base_url_idx, stringtable )
+    @explicit_reference( Header.replication_base_url_idx, stringtable )
     header: Header;
 
     /**
@@ -298,5 +309,8 @@ archive Osm {
      * List of strings separated by `\0`.
      */
     stringtable: raw_data;
+
+    @optional
+    ids: archive Ids;
 }
 } // namespace osm

--- a/osmflat/Cargo.toml
+++ b/osmflat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osmflat"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "boxdot <d@zerovolt.org>",
     "Christian Vetter <veaac.fdirct@gmail.com>",

--- a/osmflat/Cargo.toml
+++ b/osmflat/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
 smallvec = "1.4.2"
 svg = "0.10.0"
+argh = "0.1.7"
 
 [features]
 default = []

--- a/osmflat/examples/debug.rs
+++ b/osmflat/examples/debug.rs
@@ -9,8 +9,8 @@
 //!
 //! The code in this example file is released into the Public Domain.
 
+use argh::FromArgs;
 use osmflat::{iter_tags, FileResourceStorage, Osm, RelationMembersRef};
-use structopt::StructOpt;
 
 use std::path::PathBuf;
 use std::str::{self, Utf8Error};
@@ -112,23 +112,22 @@ impl<'ar> Member<'ar> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+/// output osmflatdata: nodes, ways, and/or relations
+#[derive(FromArgs, Debug)]
 struct Args {
-    /// Input osmflat archive
-    #[structopt(parse(from_os_str))]
+    /// input osmflat archive
+    #[argh(positional)]
     input: PathBuf,
-    /// Output PNG filename
-    #[structopt(
-        help = "Which types to print: (n)odes, (w)ays, or (r)elations",
-        default_value = "nwr"
-    )]
+    /// which types to print: (n)odes, (w)ays, or (r)elations
+    #[argh(option, default = "\"nwr\".to_string()")]
     types: String,
-    #[structopt(long, help = "Amount of entities to print")]
+    /// amount of entities to print
+    #[argh(option)]
     num: Option<usize>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let args = Args::from_args();
+    let args: Args = argh::from_env();
     let archive = Osm::open(FileResourceStorage::new(args.input))?;
 
     let header = archive.header();

--- a/osmflat/examples/debug.rs
+++ b/osmflat/examples/debug.rs
@@ -9,56 +9,36 @@
 //!
 //! The code in this example file is released into the Public Domain.
 
-use osmflat::{iter_tags, FileResourceStorage, Osm, RelationMembersRef, COORD_SCALE};
+use osmflat::{iter_tags, FileResourceStorage, Osm, RelationMembersRef};
+use structopt::StructOpt;
 
-use std::fmt;
+use std::path::PathBuf;
 use std::str::{self, Utf8Error};
-
-/// Represents fixed point coordinates stored in OSM
-#[derive(Clone, Copy)]
-struct FixedI64(i64);
-
-impl FixedI64 {
-    fn value(self) -> f64 {
-        self.0 as f64 / COORD_SCALE as f64
-    }
-}
-
-impl fmt::Debug for FixedI64 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let value: f64 = self.value();
-        write!(f, "{}", value)
-    }
-}
 
 #[derive(Debug)]
 struct Header<'ar> {
     #[allow(unused)]
-    bbox: (FixedI64, FixedI64, FixedI64, FixedI64),
-    #[allow(unused)]
-    required_features: Vec<&'ar str>,
-    #[allow(unused)]
-    optional_features: Vec<&'ar str>,
+    bbox: (f64, f64, f64, f64),
     #[allow(unused)]
     writingprogram: &'ar str,
     #[allow(unused)]
     source: &'ar str,
     #[allow(unused)]
-    osmosis_replication_timestamp: i64,
+    replication_timestamp: i64,
     #[allow(unused)]
-    osmosis_replication_sequence_number: i64,
+    replication_sequence_number: i64,
     #[allow(unused)]
-    osmosis_replication_base_url: &'ar str,
+    replication_base_url: &'ar str,
 }
 
 #[derive(Debug)]
 struct Node<'ar> {
     #[allow(unused)]
-    id: i64,
+    id: Option<u64>,
     #[allow(unused)]
-    lat: FixedI64,
+    lat: f64,
     #[allow(unused)]
-    lon: FixedI64,
+    lon: f64,
     #[allow(unused)]
     tags: Vec<(&'ar str, &'ar str)>,
 }
@@ -66,7 +46,7 @@ struct Node<'ar> {
 #[derive(Debug)]
 struct Way<'ar> {
     #[allow(unused)]
-    id: i64,
+    id: Option<u64>,
     #[allow(unused)]
     tags: Vec<(&'ar str, &'ar str)>,
     #[allow(unused)]
@@ -76,7 +56,7 @@ struct Way<'ar> {
 #[derive(Debug)]
 struct Relation<'ar> {
     #[allow(unused)]
-    id: i64,
+    id: Option<u64>,
     #[allow(unused)]
     tags: Vec<(&'ar str, &'ar str)>,
     #[allow(unused)]
@@ -86,7 +66,7 @@ struct Relation<'ar> {
 #[derive(Debug)]
 struct Member<'ar> {
     #[allow(unused)]
-    type_: Type,
+    r#type: Type,
     #[allow(unused)]
     idx: Option<u64>,
     #[allow(unused)]
@@ -112,17 +92,17 @@ impl<'ar> Member<'ar> {
             .map(move |member| {
                 let res = match member {
                     RelationMembersRef::NodeMember(m) => Member {
-                        type_: Type::Node,
+                        r#type: Type::Node,
                         idx: m.node_idx(),
                         role: strings.substring(m.role_idx() as usize)?,
                     },
                     RelationMembersRef::WayMember(m) => Member {
-                        type_: Type::Way,
+                        r#type: Type::Way,
                         idx: m.way_idx(),
                         role: strings.substring(m.role_idx() as usize)?,
                     },
                     RelationMembersRef::RelationMember(m) => Member {
-                        type_: Type::Relation,
+                        r#type: Type::Relation,
                         idx: m.relation_idx(),
                         role: strings.substring(m.role_idx() as usize)?,
                     },
@@ -132,43 +112,43 @@ impl<'ar> Member<'ar> {
     }
 }
 
+#[derive(StructOpt, Debug)]
+struct Args {
+    /// Input osmflat archive
+    #[structopt(parse(from_os_str))]
+    input: PathBuf,
+    /// Output PNG filename
+    #[structopt(
+        help = "Which types to print: (n)odes, (w)ays, or (r)elations",
+        default_value = "nwr"
+    )]
+    types: String,
+    #[structopt(long, help = "Amount of entities to print")]
+    num: Option<usize>,
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut args = std::env::args().skip(1).take(2);
-    let archive_dir = args.next().ok_or(
-        "USAGE: debug <osmflat-archive> [TYPES] \
-         TYPES can be any combination of 'n', 'w', 'r' (default: 'nwr').",
-    )?;
-    let types = args.next().unwrap_or_else(|| "nrw".to_string());
-    let archive = Osm::open(FileResourceStorage::new(archive_dir))?;
+    let args = Args::from_args();
+    let archive = Osm::open(FileResourceStorage::new(args.input))?;
 
     let header = archive.header();
     let strings = archive.stringtable();
 
-    let required_features: Result<Vec<_>, _> = (header.required_feature_first_idx() as usize..)
-        .take(header.required_features_size() as usize)
-        .map(|idx| strings.substring(idx))
-        .collect();
-    let optional_features: Result<Vec<_>, _> = (header.optional_feature_first_idx() as usize..)
-        .take(header.optional_features_size() as usize)
-        .map(|idx| strings.substring(idx))
-        .collect();
+    let scale_coord = |x| x as f64 / header.coord_scale() as f64;
 
     // print header
     let header = Header {
         bbox: (
-            FixedI64(header.bbox_left()),
-            FixedI64(header.bbox_right()),
-            FixedI64(header.bbox_top()),
-            FixedI64(header.bbox_bottom()),
+            scale_coord(header.bbox_left()),
+            scale_coord(header.bbox_right()),
+            scale_coord(header.bbox_top()),
+            scale_coord(header.bbox_bottom()),
         ),
-        required_features: required_features?,
-        optional_features: optional_features?,
         writingprogram: strings.substring(header.writingprogram_idx() as usize)?,
         source: strings.substring(header.source_idx() as usize)?,
-        osmosis_replication_timestamp: header.osmosis_replication_timestamp(),
-        osmosis_replication_sequence_number: header.osmosis_replication_sequence_number(),
-        osmosis_replication_base_url: strings
-            .substring(header.osmosis_replication_base_url_idx() as usize)?,
+        replication_timestamp: header.replication_timestamp(),
+        replication_sequence_number: header.replication_sequence_number(),
+        replication_base_url: strings.substring(header.replication_base_url_idx() as usize)?,
     };
     println!("{:#?}", header);
 
@@ -182,12 +162,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // print nodes
-    if types.contains('n') {
-        for node in &archive.nodes()[..3] {
+    let mut node_ids = archive.ids().map(|x| x.nodes()).into_iter().flatten();
+    if args.types.contains('n') {
+        for node in archive.nodes().iter().take(args.num.unwrap_or(usize::MAX)) {
             let node = Node {
-                id: node.id(),
-                lat: FixedI64(node.lat()),
-                lon: FixedI64(node.lon()),
+                id: node_ids.next().map(|x| x.value()),
+                lat: scale_coord(node.lat()),
+                lon: scale_coord(node.lon()),
                 tags: collect_utf8_tags(node.tags()),
             };
 
@@ -197,10 +178,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // print ways
     let nodes_index = archive.nodes_index();
-    if types.contains('w') {
-        for way in archive.ways() {
+    let mut way_ids = archive.ids().map(|x| x.ways()).into_iter().flatten();
+    if args.types.contains('w') {
+        for way in archive.ways().iter().take(args.num.unwrap_or(usize::MAX)) {
             let way = Way {
-                id: way.id(),
+                id: way_ids.next().map(|x| x.value()),
                 tags: collect_utf8_tags(way.tags()),
                 nodes: way
                     .refs()
@@ -213,11 +195,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // print relations
-    if types.contains('r') {
-        for (relation_idx, relation) in archive.relations()[..3].iter().enumerate() {
+    let mut relation_ids = archive.ids().map(|x| x.ways()).into_iter().flatten();
+    if args.types.contains('r') {
+        for (relation_idx, relation) in archive.relations()[..3]
+            .iter()
+            .take(args.num.unwrap_or(usize::MAX))
+            .enumerate()
+        {
             let members: Result<Vec<_>, _> = Member::new_slice(&archive, relation_idx).collect();
             let relation = Relation {
-                id: relation.id(),
+                id: relation_ids.next().map(|x| x.value()),
                 tags: collect_utf8_tags(relation.tags()),
                 members: members?,
             };

--- a/osmflat/examples/render-features.rs
+++ b/osmflat/examples/render-features.rs
@@ -57,7 +57,7 @@ impl GeoCoord {
 
 /// Convert osmflat Node into GeoCoord.
 impl GeoCoord {
-    fn from_node(node: &Node, coord_scale: u64) -> Self {
+    fn from_node(node: &Node, coord_scale: i32) -> Self {
         Self {
             lat: node.lat() as f64 / coord_scale as f64,
             lon: node.lon() as f64 / coord_scale as f64,

--- a/osmflat/examples/render-roads.rs
+++ b/osmflat/examples/render-roads.rs
@@ -23,7 +23,7 @@ struct GeoCoord {
 
 /// Convert osmflat Node into GeoCoord.
 impl GeoCoord {
-    fn from_node(node: &Node, coord_scale: u64) -> Self {
+    fn from_node(node: &Node, coord_scale: i32) -> Self {
         Self {
             lat: node.lat() as f64 / coord_scale as f64,
             lon: node.lon() as f64 / coord_scale as f64,

--- a/osmflat/examples/road-length.rs
+++ b/osmflat/examples/road-length.rs
@@ -21,10 +21,10 @@ struct Coords {
 }
 
 impl Coords {
-    fn from_node(node: &Node) -> Self {
+    fn from_node(node: &Node, coord_scale: u64) -> Self {
         Self {
-            lat: node.lat() as f64 / osmflat::COORD_SCALE as f64,
-            lon: node.lon() as f64 / osmflat::COORD_SCALE as f64,
+            lat: node.lat() as f64 / coord_scale as f64,
+            lon: node.lon() as f64 / coord_scale as f64,
         }
     }
 }
@@ -46,6 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .nth(1)
         .ok_or("USAGE: road_length <osmflat-archive>")?;
     let archive = Osm::open(FileResourceStorage::new(archive_dir))?;
+    let header = archive.header();
 
     let tags = archive.tags();
     let tags_index = archive.tags_index();
@@ -71,6 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // This is a common pattern when flattening 1 to n relations.
             Some(Coords::from_node(
                 &nodes[nodes_index[idx as usize].value()? as usize],
+                header.coord_scale(),
             ))
         });
         let length: Option<f64> = coords

--- a/osmflat/examples/road-length.rs
+++ b/osmflat/examples/road-length.rs
@@ -21,7 +21,7 @@ struct Coords {
 }
 
 impl Coords {
-    fn from_node(node: &Node, coord_scale: u64) -> Self {
+    fn from_node(node: &Node, coord_scale: i32) -> Self {
         Self {
             lat: node.lat() as f64 / coord_scale as f64,
             lon: node.lon() as f64 / coord_scale as f64,

--- a/osmflatc/Cargo.toml
+++ b/osmflatc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osmflatc"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "boxdot <d@zerovolt.org>",
     "Christian Vetter <veaac.fdirct@gmail.com>",
@@ -26,7 +26,7 @@ flate2 = "1.0.18"
 itertools = "0.10.3"
 log = "0.4.11"
 memmap2 = "0.5.7"
-osmflat = "0.1.0"
+osmflat = "0.2.0"
 parking_lot = "0.11.0"
 pbr = "1.0.3"
 prost = "0.11.0"

--- a/osmflatc/src/args.rs
+++ b/osmflatc/src/args.rs
@@ -13,4 +13,8 @@ pub struct Args {
 
     /// Output directory for OSM flatdata archive
     pub output: PathBuf,
+
+    /// Whether to compile the optional ids subs
+    #[structopt(long = "ids")]
+    pub ids: bool,
 }

--- a/osmflatc/src/main.rs
+++ b/osmflatc/src/main.rs
@@ -251,6 +251,7 @@ fn resolve_ways(
     (result, stats)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn serialize_ways(
     block: &osmpbf::PrimitiveBlock,
     nodes_id_to_idx: &[Option<u64>],

--- a/osmflatc/src/main.rs
+++ b/osmflatc/src/main.rs
@@ -27,49 +27,37 @@ type Error = Box<dyn std::error::Error>;
 
 fn serialize_header(
     header_block: &osmpbf::HeaderBlock,
+    coord_scale: u64,
     builder: &osmflat::OsmBuilder,
     stringtable: &mut StringTable,
 ) -> io::Result<()> {
     let mut header = osmflat::Header::new();
 
+    header.set_coord_scale(coord_scale);
+
     if let Some(ref bbox) = header_block.bbox {
-        header.set_bbox_left(bbox.left);
-        header.set_bbox_right(bbox.right);
-        header.set_bbox_top(bbox.top);
-        header.set_bbox_bottom(bbox.bottom);
+        header.set_bbox_left(bbox.left / (1000000000 / coord_scale) as i64);
+        header.set_bbox_right(bbox.right / (1000000000 / coord_scale) as i64);
+        header.set_bbox_top(bbox.top / (1000000000 / coord_scale) as i64);
+        header.set_bbox_bottom(bbox.bottom / (1000000000 / coord_scale) as i64);
     };
 
-    header.set_required_feature_first_idx(stringtable.next_index());
-    header.set_required_features_size(header_block.required_features.len() as u32);
-    for feature in &header_block.required_features {
-        stringtable.insert(feature);
-    }
-
-    header.set_optional_feature_first_idx(stringtable.next_index());
-    header.set_optional_features_size(header_block.optional_features.len() as u32);
-    for feature in &header_block.optional_features {
-        stringtable.insert(feature);
-    }
-
-    if let Some(ref writingprogram) = header_block.writingprogram {
-        // TODO: Should we also add our name here?
-        header.set_writingprogram_idx(stringtable.insert(writingprogram));
-    }
+    header.set_writingprogram_idx(stringtable.insert("osmflatc"));
 
     if let Some(ref source) = header_block.source {
         header.set_source_idx(stringtable.insert(source));
     }
 
     if let Some(timestamp) = header_block.osmosis_replication_timestamp {
-        header.set_osmosis_replication_timestamp(timestamp);
+        header.set_replication_timestamp(timestamp);
     }
 
     if let Some(number) = header_block.osmosis_replication_sequence_number {
-        header.set_osmosis_replication_sequence_number(number);
+        header.set_replication_sequence_number(number);
     }
 
     if let Some(ref url) = header_block.osmosis_replication_base_url {
-        header.set_osmosis_replication_base_url_idx(stringtable.insert(url));
+        header.set_replication_base_url_idx(stringtable.insert(url));
     }
 
     builder.set_header(&header)?;
@@ -178,7 +166,9 @@ fn add_string_table(
 
 fn serialize_dense_nodes(
     block: &osmpbf::PrimitiveBlock,
+    granularity: u64,
     nodes: &mut flatdata::ExternalVector<osmflat::Node>,
+    node_ids: &mut Option<flatdata::ExternalVector<osmflat::Id>>,
     nodes_id_to_idx: &mut ids::IdTableBuilder,
     stringtable: &mut StringTable,
     tags: &mut TagSerializer,
@@ -188,7 +178,7 @@ fn serialize_dense_nodes(
     for group in block.primitivegroup.iter() {
         let dense_nodes = group.dense.as_ref().unwrap();
 
-        let granularity = block.granularity.unwrap_or(100);
+        let pbf_granularity = block.granularity.unwrap_or(100);
         let lat_offset = block.lat_offset.unwrap_or(0);
         let lon_offset = block.lon_offset.unwrap_or(0);
         let mut lat = 0;
@@ -204,12 +194,14 @@ fn serialize_dense_nodes(
             assert_eq!(index as usize, nodes.len());
 
             let node = nodes.grow()?;
-            node.set_id(id);
+            if let Some(ids) = node_ids {
+                ids.grow()?.set_value(id as u64);
+            }
 
             lat += dense_nodes.lat[i];
             lon += dense_nodes.lon[i];
-            node.set_lat(lat_offset + (i64::from(granularity) * lat));
-            node.set_lon(lon_offset + (i64::from(granularity) * lon));
+            node.set_lat((lat_offset + (i64::from(pbf_granularity) * lat)) / granularity as i64);
+            node.set_lon((lon_offset + (i64::from(pbf_granularity) * lon)) / granularity as i64);
 
             if tags_offset < dense_nodes.keys_vals.len() {
                 node.set_tag_first_idx(tags.next_index());
@@ -259,6 +251,7 @@ fn serialize_ways(
     block: &osmpbf::PrimitiveBlock,
     nodes_id_to_idx: &[Option<u64>],
     ways: &mut flatdata::ExternalVector<osmflat::Way>,
+    way_ids: &mut Option<flatdata::ExternalVector<osmflat::Id>>,
     ways_id_to_idx: &mut ids::IdTableBuilder,
     stringtable: &mut StringTable,
     tags: &mut TagSerializer,
@@ -273,7 +266,9 @@ fn serialize_ways(
             assert_eq!(index as usize, ways.len());
 
             let way = ways.grow()?;
-            way.set_id(pbf_way.id);
+            if let Some(ids) = way_ids {
+                ids.grow()?.set_value(pbf_way.id as u64);
+            }
 
             debug_assert_eq!(pbf_way.keys.len(), pbf_way.vals.len(), "invalid input data");
             way.set_tag_first_idx(tags.next_index());
@@ -327,6 +322,7 @@ fn serialize_relations(
     relations_id_to_idx: &ids::IdTable,
     stringtable: &mut StringTable,
     relations: &mut flatdata::ExternalVector<osmflat::Relation>,
+    relation_ids: &mut Option<flatdata::ExternalVector<osmflat::Id>>,
     relation_members: &mut flatdata::MultiVector<osmflat::RelationMembers>,
     tags: &mut TagSerializer,
 ) -> Result<Stats, Error> {
@@ -335,7 +331,9 @@ fn serialize_relations(
     for group in &block.primitivegroup {
         for pbf_relation in &group.relations {
             let relation = relations.grow()?;
-            relation.set_id(pbf_relation.id);
+            if let Some(ids) = relation_ids {
+                ids.grow()?.set_value(pbf_relation.id as u64);
+            }
 
             debug_assert_eq!(
                 pbf_relation.keys.len(),
@@ -399,6 +397,8 @@ fn serialize_relations(
 
 fn serialize_dense_node_blocks(
     builder: &osmflat::OsmBuilder,
+    granularity: u64,
+    mut node_ids: Option<flatdata::ExternalVector<osmflat::Id>>,
     blocks: Vec<BlockIndex>,
     data: &[u8],
     tags: &mut TagSerializer,
@@ -415,8 +415,15 @@ fn serialize_dense_node_blocks(
         |idx| read_block(data, &idx),
         |block| -> Result<osmpbf::PrimitiveBlock, Error> {
             let block = block?;
-            *stats +=
-                serialize_dense_nodes(&block, &mut nodes, &mut nodes_id_to_idx, stringtable, tags)?;
+            *stats += serialize_dense_nodes(
+                &block,
+                granularity,
+                &mut nodes,
+                &mut node_ids,
+                &mut nodes_id_to_idx,
+                stringtable,
+                tags,
+            )?;
 
             pb.inc();
             Ok(block)
@@ -427,6 +434,9 @@ fn serialize_dense_node_blocks(
     // of the last node
     nodes.grow()?.set_tag_first_idx(tags.next_index());
     nodes.close()?;
+    if let Some(ids) = node_ids {
+        ids.close()?;
+    }
     info!("Dense nodes converted.");
     info!("Building dense nodes index...");
     let nodes_id_to_idx = nodes_id_to_idx.build();
@@ -438,6 +448,7 @@ type PrimitiveBlockWithIds = (osmpbf::PrimitiveBlock, (Vec<Option<u64>>, Stats))
 
 fn serialize_way_blocks(
     builder: &osmflat::OsmBuilder,
+    mut way_ids: Option<flatdata::ExternalVector<osmflat::Id>>,
     blocks: Vec<BlockIndex>,
     data: &[u8],
     nodes_id_to_idx: &ids::IdTable,
@@ -464,6 +475,7 @@ fn serialize_way_blocks(
                 &block,
                 &ids,
                 &mut ways,
+                &mut way_ids,
                 &mut ways_id_to_idx,
                 stringtable,
                 tags,
@@ -481,6 +493,9 @@ fn serialize_way_blocks(
         sentinel.set_ref_first_idx(nodes_index.len() as u64);
     }
     ways.close()?;
+    if let Some(ids) = way_ids {
+        ids.close()?;
+    }
     nodes_index.close()?;
 
     info!("Ways converted.");
@@ -493,6 +508,7 @@ fn serialize_way_blocks(
 #[allow(clippy::too_many_arguments)]
 fn serialize_relation_blocks(
     builder: &osmflat::OsmBuilder,
+    mut relation_ids: Option<flatdata::ExternalVector<osmflat::Id>>,
     blocks: Vec<BlockIndex>,
     data: &[u8],
     nodes_id_to_idx: &ids::IdTable,
@@ -522,6 +538,7 @@ fn serialize_relation_blocks(
                 &relations_id_to_idx,
                 stringtable,
                 &mut relations,
+                &mut relation_ids,
                 &mut relation_members,
                 tags,
             )?;
@@ -536,6 +553,9 @@ fn serialize_relation_blocks(
     }
 
     relations.close()?;
+    if let Some(ids) = relation_ids {
+        ids.close()?;
+    }
     relation_members.close()?;
 
     info!("Relations converted.");
@@ -543,12 +563,21 @@ fn serialize_relation_blocks(
     Ok(())
 }
 
+fn gcd(a: u64, b: u64) -> u64 {
+    let (mut x, mut y) = (a.min(b), a.max(b));
+    while x > 1 {
+        y %= x;
+        std::mem::swap(&mut x, &mut y);
+    }
+    y
+}
+
 fn run(args: args::Args) -> Result<(), Error> {
     let input_file = File::open(&args.input)?;
     let input_data = unsafe { Mmap::map(&input_file)? };
 
     let storage = FileResourceStorage::new(args.output.clone());
-    let builder = osmflat::OsmBuilder::new(storage)?;
+    let builder = osmflat::OsmBuilder::new(storage.clone())?;
 
     // TODO: Would be nice not store all these strings in memory, but to flush them
     // from time to time to disk.
@@ -562,6 +591,20 @@ fn run(args: args::Args) -> Result<(), Error> {
 
     info!("Building index of PBF blocks...");
     let block_index = build_block_index(&input_data);
+    let mut greatest_common_granularity = 1000000000;
+    for block in &block_index {
+        if block.block_type == BlockType::DenseNodes {
+            // only DenseNodes have coordinate we need to scale
+            if let Some(block_granularity) = block.granularity {
+                greatest_common_granularity = gcd(greatest_common_granularity, block_granularity);
+            }
+        }
+    }
+    let coord_scale = 1000000000 / greatest_common_granularity;
+    info!(
+        "Greatest common granularity: {}, Coordinate scaling factor: {}",
+        greatest_common_granularity, coord_scale
+    );
 
     // TODO: move out into a function
     let groups = block_index.into_iter().group_by(|b| b.block_type);
@@ -590,13 +633,26 @@ fn run(args: args::Args) -> Result<(), Error> {
     }
     let idx = &pbf_header[0];
     let pbf_header: osmpbf::HeaderBlock = read_block(&input_data, idx)?;
-    serialize_header(&pbf_header, &builder, &mut stringtable)?;
+    serialize_header(&pbf_header, coord_scale, &builder, &mut stringtable)?;
     info!("Header written.");
 
     let mut stats = Stats::default();
 
+    let ids_archive;
+    let mut node_ids = None;
+    let mut way_ids = None;
+    let mut relation_ids = None;
+    if args.ids {
+        ids_archive = builder.ids()?;
+        node_ids = Some(ids_archive.start_nodes()?);
+        way_ids = Some(ids_archive.start_ways()?);
+        relation_ids = Some(ids_archive.start_relations()?);
+    }
+
     let nodes_id_to_idx = serialize_dense_node_blocks(
         &builder,
+        greatest_common_granularity,
+        node_ids,
         pbf_dense_nodes,
         &input_data,
         &mut tags,
@@ -606,6 +662,7 @@ fn run(args: args::Args) -> Result<(), Error> {
 
     let ways_id_to_idx = serialize_way_blocks(
         &builder,
+        way_ids,
         pbf_ways,
         &input_data,
         &nodes_id_to_idx,
@@ -616,6 +673,7 @@ fn run(args: args::Args) -> Result<(), Error> {
 
     serialize_relation_blocks(
         &builder,
+        relation_ids,
         pbf_relations,
         &input_data,
         &nodes_id_to_idx,
@@ -632,6 +690,11 @@ fn run(args: args::Args) -> Result<(), Error> {
     builder.set_stringtable(&stringtable.into_bytes())?;
 
     info!("osmflat archive built.");
+
+    std::mem::drop(builder);
+    osmflat::Osm::open(storage)?;
+
+    info!("verified that osmflat archive can be opened.");
 
     println!("{}", stats);
     Ok(())

--- a/osmflatc/src/main.rs
+++ b/osmflatc/src/main.rs
@@ -399,6 +399,7 @@ fn serialize_relations(
     Ok(stats)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn serialize_dense_node_blocks(
     builder: &osmflat::OsmBuilder,
     granularity: i32,
@@ -450,6 +451,7 @@ fn serialize_dense_node_blocks(
 
 type PrimitiveBlockWithIds = (osmpbf::PrimitiveBlock, (Vec<Option<u64>>, Stats));
 
+#[allow(clippy::too_many_arguments)]
 fn serialize_way_blocks(
     builder: &osmflat::OsmBuilder,
     mut way_ids: Option<flatdata::ExternalVector<osmflat::Id>>,

--- a/osmflatc/src/osmpbf.rs
+++ b/osmflatc/src/osmpbf.rs
@@ -43,7 +43,7 @@ pub fn type_and_granularity_from_osmdata_blob(mut blob: &[u8]) -> io::Result<(Bl
     while !blob.is_empty() {
         // decode fields of PrimitiveBlock
         let (key, wire_type) = prost::encoding::decode_key(&mut blob)?;
-        let blob_copy = blob.clone();
+        let mut blob_copy = blob;
         if key == PRIMITIVE_GROUP_TAG {
             // We found a PrimitiveGroup field. There could be several of them, but
             // follwoing the specs of OSMPBF, all of them will have the same single

--- a/osmflatc/src/strings.rs
+++ b/osmflatc/src/strings.rs
@@ -66,10 +66,6 @@ impl StringTable {
         Default::default()
     }
 
-    pub fn next_index(&self) -> u64 {
-        self.size_in_bytes
-    }
-
     /// Inserts a string into string table and returns its index.
     ///
     /// If the string was already inserted before, the string is deduplicated


### PR DESCRIPTION
* Store granularity explicitly instead of pre-multiplied numbers
* Move Ids to separate optional sub-archive
* Reduce bits needed for coordinates from 40 to 32
* Remove unused header information

Comparison:

Comparing:
* Compressed PBF (internal zlib compression)
* Unpacked osmflat with and without optional Ids (only new version has them optional)
* Compression with pzstd level 3
* Compression with shuffly ( https://github.com/VeaaC/shuffly ) + pzstd level 3

Before:

| Dataset  | PBF (zlib) | osmflat w Ids | zstd + osmflat w Ids | shuffly + zstd + osmflat w Ids |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Berlin  | 70M  | 227M  | 94M  | 58M  |
| Europe  | 26G  | 89G  | 41G  | 23G  |
| Planet | 66G  | 223G  | 102G  | 57G  |

After:

| Dataset  | PBF (zlib) | osmflat w Ids | osmflat w/o Ids | zstd + osmflat w Ids | zstd + osmflat w/o Ids | shuffly + zstd + osmflat w Ids | shuffly + zstd + osmflat w/o Ids |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| Berlin  | 70M  | 214M  | 176M  | 83M  | 69M  | 53M  | 49M  |
| Europe  | 26G  | 84G  | 68G  | 36G  | 30G  | 20G  | 19G  |
| Planet | 66G  | 208G  | 164G  | 97G  | 76G  | 48G  | 47G  |

Observations:
* More compact in all scenarios.
* Using shuffly is still worth it (Ids have a compression ratio of > factor 20), but a bit less so due to rearranged data, and granularity.
* Shuffly compressed version is smaller than compressed PBF (with and without Ids)
* Most people might want to use a version without ids since it saves disk space
* Ids are almost for free if compressed with shuffly (due to data being sorted by id)
