### PR TITLE
Speed up osmflatc:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
 
 [patch.crates-io]
 osmflat = { path = "osmflat" }
+
+[profile.release]
+debug = true

--- a/osmflatc/Cargo.toml
+++ b/osmflatc/Cargo.toml
@@ -34,6 +34,7 @@ prost = "0.11.0"
 prost-derive = "0.11.0"
 prost-types = "0.11.1"
 rayon = "1.4.1"
+ahash = "0.8.0"
 
 [build-dependencies]
 prost-build = "0.11.1"

--- a/osmflatc/src/main.rs
+++ b/osmflatc/src/main.rs
@@ -378,13 +378,8 @@ fn serialize_dense_node_blocks(
         |idx| read_block(data, &idx),
         |block| -> Result<osmpbf::PrimitiveBlock, Error> {
             let block = block?;
-            *stats += serialize_dense_nodes(
-                &block,
-                &mut nodes,
-                &mut nodes_id_to_idx,
-                stringtable,
-                tags,
-            )?;
+            *stats +=
+                serialize_dense_nodes(&block, &mut nodes, &mut nodes_id_to_idx, stringtable, tags)?;
 
             pb.inc();
             Ok(block)

--- a/osmflatc/src/main.rs
+++ b/osmflatc/src/main.rs
@@ -17,7 +17,8 @@ use log::info;
 use memmap2::Mmap;
 use pbr::ProgressBar;
 
-use std::collections::{hash_map, HashMap};
+use ahash::AHashMap;
+use std::collections::hash_map;
 use std::fs::File;
 use std::io;
 use std::str;
@@ -79,7 +80,7 @@ fn serialize_header(
 struct TagSerializer<'a> {
     tags: flatdata::ExternalVector<'a, osmflat::Tag>,
     tags_index: flatdata::ExternalVector<'a, osmflat::TagIndex>,
-    dedup: HashMap<(u64, u64), u64>, // deduplication table: (key_idx, val_idx) -> pos
+    dedup: AHashMap<(u64, u64), u64>, // deduplication table: (key_idx, val_idx) -> pos
 }
 
 impl<'a> TagSerializer<'a> {
@@ -87,7 +88,7 @@ impl<'a> TagSerializer<'a> {
         Ok(Self {
             tags: builder.start_tags()?,
             tags_index: builder.start_tags_index()?,
-            dedup: HashMap::new(),
+            dedup: AHashMap::new(),
         })
     }
 
@@ -375,9 +376,10 @@ fn serialize_dense_node_blocks(
     parallel::parallel_process(
         blocks.into_iter(),
         |idx| read_block(data, &idx),
-        |block| -> Result<(), Error> {
+        |block| -> Result<osmpbf::PrimitiveBlock, Error> {
+            let block = block?;
             *stats += serialize_dense_nodes(
-                &block?,
+                &block,
                 &mut nodes,
                 &mut nodes_id_to_idx,
                 stringtable,
@@ -385,7 +387,7 @@ fn serialize_dense_node_blocks(
             )?;
 
             pb.inc();
-            Ok(())
+            Ok(block)
         },
     )?;
 
@@ -423,7 +425,7 @@ fn serialize_way_blocks(
             let ids = resolve_ways(&block, nodes_id_to_idx);
             Ok((block, ids))
         },
-        |block: io::Result<PrimitiveBlockWithIds>| -> Result<(), Error> {
+        |block: io::Result<PrimitiveBlockWithIds>| -> Result<osmpbf::PrimitiveBlock, Error> {
             let (block, (ids, stats_resolve)) = block?;
             *stats += stats_resolve;
             *stats += serialize_ways(
@@ -436,7 +438,8 @@ fn serialize_way_blocks(
                 &mut nodes_index,
             )?;
             pb.inc();
-            Ok(())
+
+            Ok(block)
         },
     )?;
 
@@ -478,9 +481,10 @@ fn serialize_relation_blocks(
     parallel::parallel_process(
         blocks.into_iter(),
         |idx| read_block(data, &idx),
-        |block| -> Result<(), Error> {
+        |block| -> Result<osmpbf::PrimitiveBlock, Error> {
+            let block = block?;
             *stats += serialize_relations(
-                &block?,
+                &block,
                 nodes_id_to_idx,
                 ways_id_to_idx,
                 &relations_id_to_idx,
@@ -490,7 +494,7 @@ fn serialize_relation_blocks(
                 tags,
             )?;
             pb.inc();
-            Ok(())
+            Ok(block)
         },
     )?;
 

--- a/osmflatc/src/strings.rs
+++ b/osmflatc/src/strings.rs
@@ -1,9 +1,9 @@
+use ahash::AHashMap;
 use inlinable_string::{InlinableString, StringExt};
-use std::collections::HashMap;
 
 #[derive(Debug, Default)]
 pub struct StringTable {
-    indexed_data: HashMap<InlinableString, u64>,
+    indexed_data: AHashMap<InlinableString, u64>,
     size_in_bytes: u64,
 }
 


### PR DESCRIPTION
* drop heavy (due to prost memory allocation) object in separate thread
* use faster hash function (ahash)
* Total speedup ~40% faster (7m for Europe instead of 10m)